### PR TITLE
Fix: Redirection in Calendar.Entry with invalid guid

### DIFF
--- a/TournamentCalendar/Controllers/Calendar.cs
+++ b/TournamentCalendar/Controllers/Calendar.cs
@@ -60,6 +60,11 @@ public class Calendar : ControllerBase
     {
         ViewBag.TitleTagText = "Volleyballturnier in den Kalender eintragen";
 
+        if (!string.IsNullOrEmpty(guid) && !Guid.TryParse(guid, out _))
+        {
+            return NotFound();
+        }
+
         var model = await new EditModel().Initialize(cancellationToken);
         if (string.IsNullOrEmpty(guid))
         {
@@ -71,7 +76,7 @@ public class Calendar : ControllerBase
         model.LoadTournament(guid, cancellationToken);
 
         return model.IsNew  // id not found
-            ? (ActionResult)RedirectToAction(nameof(Calendar.Entry), nameof(Controllers.Calendar), new { id = string.Empty })
+            ? RedirectToAction(nameof(Calendar.Entry), nameof(Controllers.Calendar), new { guid = string.Empty })
             : View(ViewName.Calendar.Edit, model);
     }
 

--- a/TournamentCalendar/TournamentCalendar.csproj
+++ b/TournamentCalendar/TournamentCalendar.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-        <Version>2.1.0</Version>
-        <FileVersion>2.1.0</FileVersion>
+        <Version>2.1.1</Version>
+        <FileVersion>2.1.1</FileVersion>
         <EnableDefaultContentItems>true</EnableDefaultContentItems>
         <Authors>axuno gGmbH</Authors>
         <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>


### PR DESCRIPTION
When the `guid` parameter is not a valild `Guid`, a `NotFound` result is returned