### PR TITLE
Enhance CalendarRepository with caching

### DIFF
--- a/Data/CountriesRepository.cs
+++ b/Data/CountriesRepository.cs
@@ -20,6 +20,5 @@ public class CountriesRepository : GenericRepository
         }
 
         da.FetchEntityCollection(countries, bucket);
-        da.CloseConnection();
     }
 }

--- a/Data/DbContext.cs
+++ b/Data/DbContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using SD.LLBLGen.Pro.ORMSupportClasses;
 using TournamentCalendarDAL.DatabaseSpecific;
 
@@ -18,7 +17,6 @@ public class DbContext : IDbContext
     {
         AppDb = new AppDb(this);
     }
-        
        
     /// <summary>
     /// The connection key used to retrieve the <see cref="ConnectionString"/>.
@@ -48,7 +46,7 @@ public class DbContext : IDbContext
     /// Set this prior to calling a method which executes database logic.
     /// </remarks>
     public virtual int CommandTimeOut { get; set; } = 30;
-        
+
     /// <summary>
     /// Gets a new instance of an <see cref="IDataAccessAdapter"/> which will be used to access repositories.
     ///  </summary>
@@ -59,11 +57,10 @@ public class DbContext : IDbContext
         {
             if (!_cacheIsRegistered)
             {
-                var csb = new SqlConnectionStringBuilder(ConnectionString);
-                // see docs: https://www.llblgen.com/Documentation/4.2/LLBLGen%20Pro%20RTF/Using%20the%20generated%20code/gencode_resultsetcaching.htm
-                if (csb.PersistSecurityInfo == false) { csb.Password = string.Empty; }
+                // see docs: https://www.llblgen.com/Documentation/5.9/LLBLGen%20Pro%20RTF/Using%20the%20generated%20code/gencode_resultsetcaching.htm
                 // if connection string exists, the method simply returns without creating a new cache
-                CacheController.RegisterCache(csb.ConnectionString, new ResultsetCache(TimeSpan.FromDays(1).Seconds));
+                // ** Note ** The connection string must be EXACTLY as it's used for queries.
+                CacheController.RegisterCache(ConnectionString, new ResultsetCache(TimeSpan.FromDays(1).Seconds));
                 _cacheIsRegistered = true;
             }
                 

--- a/Data/GenericRepository.cs
+++ b/Data/GenericRepository.cs
@@ -8,7 +8,7 @@ namespace TournamentCalendar.Data;
 
 public class GenericRepository
 {
-    private static readonly ILogger _logger = AppLogging.CreateLogger<GenericRepository>();
+    protected static readonly ILogger Logger = AppLogging.CreateLogger<GenericRepository>();
     protected readonly IDbContext _dbContext;
 
     public GenericRepository(IDbContext dbContext)
@@ -20,7 +20,6 @@ public class GenericRepository
     {
         using var da = _dbContext.GetNewAdapter();
         var success = await da.SaveEntityAsync(registration, refetchAfterSave, cancellationToken);
-        da.CloseConnection();
         return success;
     }
 

--- a/Data/InfoServiceRepository.cs
+++ b/Data/InfoServiceRepository.cs
@@ -26,7 +26,6 @@ public class InfoServiceRepository : GenericRepository
     {
         using var da = _dbContext.GetNewAdapter();
         var success = da.FetchEntityUsingUniqueConstraint(entity, filter);
-        da.CloseConnection();
         return success;
     }
 

--- a/TournamentCalendar/Configuration/Credentials.Development.json
+++ b/TournamentCalendar/Configuration/Credentials.Development.json
@@ -1,6 +1,6 @@
 {
     "ConnectionStrings": {
-        "TournamentsMsSql": "Server=(LocalDB)\\MSSQLLocalDB;AttachDbFilename=\\path-to\\TournamentCalendar.mdf;Database=TournamentCalendar;Integrated Security=true",
+        "TournamentsMsSql": "Server=(LocalDB)\\MSSQLLocalDB;AttachDbFilename=\\path-to\\TournamentCalendar.mdf;Database=TournamentCalendar;Integrated Security=false;Connection Timeout=15;Pooling=true;Min Pool Size=1000;Max Pool Size=10000;MultipleActiveResultSets=true",
         "TournamentsMsSql__": "Server=localhost;Integrated Security=true"
     }
 }

--- a/TournamentCalendar/Configuration/Credentials.Production.json
+++ b/TournamentCalendar/Configuration/Credentials.Production.json
@@ -1,5 +1,5 @@
 {
     "ConnectionStrings": {
-        "TournamentsMsSql": "Server=127.0.0.1;User Id=userId;Password=my!password!;Integrated Security=false"
+        "TournamentsMsSql": "Server=127.0.0.1;User Id=userId;Password=my!password!;Integrated Security=false;Connection Timeout=15;Pooling=true;Min Pool Size=1000;Max Pool Size=10000;MultipleActiveResultSets=true"
     }
 }

--- a/TournamentCalendar/Controllers/Calendar.cs
+++ b/TournamentCalendar/Controllers/Calendar.cs
@@ -169,8 +169,14 @@ public class Calendar : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Email: {PostedByEmail}, PostedBy: {PostedByName},  TournamentName: {TournamentName}", model.PostedByEmail, model.PostedByName, model.TournamentName);
+            _logger.LogError(ex, "Email: {PostedByEmail}, PostedBy: {PostedByName},  TournamentName: {TournamentName}",
+                model.PostedByEmail, model.PostedByName, model.TournamentName);
             return View(ViewName.Calendar.Confirm, confirmationModel);
+        }
+        finally
+        {
+            // Updating the calendar requires to clear the cached results.
+            CalendarRepository.PurgeCalendarCaches();
         }
     }
 

--- a/TournamentCalendar/Models/Newsletter/NewsletterModel.cs
+++ b/TournamentCalendar/Models/Newsletter/NewsletterModel.cs
@@ -14,7 +14,7 @@ namespace TournamentCalendar.Models.Newsletter;
 public class NewsletterModel
 {
     private readonly IAppDb _appDb;
-    private EntityCollection<CalendarEntity> _tournaments = new();
+    private readonly EntityCollection<CalendarEntity> _tournaments = new();
     private readonly EntityCollection<SurfaceEntity> _surfaces = new();
     private readonly EntityCollection<PlayingAbilityEntity> _playingAbilities = new();
 
@@ -57,7 +57,9 @@ public class NewsletterModel
         await _appDb.CalendarRepository.GetAllActiveTournaments(_tournaments, cancellationToken);
         await _appDb.CalendarRepository.GetTournamentRelationshipEntities(_surfaces, _playingAbilities, cancellationToken);
 
-        _tournaments = await _appDb.CalendarRepository.GetActiveTournaments(LastSendDate);
+        _tournaments.Clear();
+        var newTournaments = await _appDb.CalendarRepository.GetActiveTournaments(LastSendDate, cancellationToken);
+        _tournaments.AddRange(newTournaments);
     }
 
     public ICollection<SentNewsletterEntity> Newsletters { get; private set; } = new HashSet<SentNewsletterEntity>();

--- a/TournamentCalendar/TournamentCalendar.csproj
+++ b/TournamentCalendar/TournamentCalendar.csproj
@@ -3,8 +3,8 @@
 	<PropertyGroup>
         <Product>TournamentCalendar</Product>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>3.0.1</Version>
-        <FileVersion>3.0.1</FileVersion>
+        <Version>3.0.3</Version>
+        <FileVersion>3.0.3</FileVersion>
         <EnableDefaultContentItems>true</EnableDefaultContentItems>
         <Authors>axuno gGmbH</Authors>
         <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>

--- a/TournamentCalendar/WebAppStartup.cs
+++ b/TournamentCalendar/WebAppStartup.cs
@@ -210,6 +210,7 @@ public static class WebAppStartup
     public static void Configure(WebApplication app, ILoggerFactory loggerFactory)
     {
         var env = app.Environment;
+        AppLogging.Configure(loggerFactory);
 
         app.UseHttpsRedirection();
 


### PR DESCRIPTION
#### Changes
* Enhance CalendarRepository with caching of sql result sets
* Fix: Stop using IDataAccessAdapter as method argument
* Updating/adding a new Calendar entry will clear the cached results
* Remove any explicit IDataAccessAdapter.CloseConnection() in all repositories
* Minor update of standard SQL connection string