### PR TITLE
Fix: Date & time picker on Safari browser

### DIFF
--- a/TournamentCalendar/TournamentCalendar.csproj
+++ b/TournamentCalendar/TournamentCalendar.csproj
@@ -3,8 +3,8 @@
 	<PropertyGroup>
         <Product>TournamentCalendar</Product>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>3.1.0</Version>
-        <FileVersion>3.1.0</FileVersion>
+        <Version>3.1.1</Version>
+        <FileVersion>3.1.1</FileVersion>
         <EnableDefaultContentItems>true</EnableDefaultContentItems>
         <Authors>axuno gGmbH</Authors>
         <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>

--- a/TournamentCalendar/Views/Calendar/Edit.cshtml
+++ b/TournamentCalendar/Views/Calendar/Edit.cshtml
@@ -372,8 +372,8 @@
 @section ScriptStandardSection
 {
     <script type="text/javascript" src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&language=de&region=DE", googleConfig.WebApiKey)"></script>
-    <script type="text/javascript" src="@Url.Content(ScriptName.Lib.TempusDominusJs)"></script>
-    <script type="text/javascript" src="@Url.Content(ScriptName.Js.Location)"></script>
+    <script type="text/javascript" src="@Url.Content(ScriptName.Lib.TempusDominusJs)" asp-append-version="true"></script>
+    <script type="text/javascript" src="@Url.Content(ScriptName.Js.Location)" asp-append-version="true"></script>
     <script type="text/javascript">
     //<![CDATA[
     'use strict';
@@ -432,6 +432,7 @@
 
         [].forEach.call(document.querySelectorAll('[data-input-type="date"]'), function (el) {
             el._tempusDominus = new tempusDominus.TempusDominus(el, {
+                container: el,
                 allowInputToggle: false,
                 localization: {
                     format: 'L'
@@ -453,6 +454,7 @@
 
         [].forEach.call(document.querySelectorAll('[data-input-type="time"]'), function (el) {
             el._tempusDominus = new tempusDominus.TempusDominus(el, {
+                container: el,
                 allowInputToggle: false,
                 stepping: 15,
                 localization: {

--- a/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -84,7 +84,7 @@
     </style>
 }
 @section ScriptStandardSection {
-<script src="@Url.Content(ScriptName.Lib.SimpleDataTablesJs)"></script>
+<script src="@Url.Content(ScriptName.Lib.SimpleDataTablesJs)" asp-append-version="true"></script>
 <script type="text/javascript">
 //<![CDATA[
     'use strict';

--- a/TournamentCalendar/Views/InfoService/Edit.cshtml
+++ b/TournamentCalendar/Views/InfoService/Edit.cshtml
@@ -169,8 +169,7 @@
 @section ScriptStandardSection {
     @* Note: Google requires an API key for all requests since 11 June 2018 *@
     <script type="text/javascript" src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&language=de&region=DE", googleConfig.WebApiKey)"></script>
-    @* Note: Bootstrap 4 relies on jQuery *@
-    <script type="text/javascript" src="@Url.Content(ScriptName.Js.Location)"></script>
+    <script type="text/javascript" src="@Url.Content(ScriptName.Js.Location)" asp-append-version="true"></script>
     <script type="text/javascript">
     //<![CDATA[
     'use strict';

--- a/TournamentCalendar/Views/Shared/_Layout.cshtml
+++ b/TournamentCalendar/Views/Shared/_Layout.cshtml
@@ -24,8 +24,8 @@
     <meta name="msapplication-config" content="/favicon/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     <!-- favicons end -->
-    <link rel="stylesheet" href="@Url.Content(CssName.Lib.BootstrapAllCss)" />
-    <link rel="stylesheet" href="@Url.Content(CssName.General.SiteCss)" />
+    <link rel="stylesheet" href="@Url.Content(CssName.Lib.BootstrapAllCss)" asp-append-version="true"/>
+    <link rel="stylesheet" href="@Url.Content(CssName.General.SiteCss)" asp-append-version="true"/>
     @if (IsSectionDefined(SectionName.CssSection))
     {@await RenderSectionAsync(SectionName.CssSection, false)}
     @if (IsSectionDefined(SectionName.ScriptHeadSection))
@@ -62,9 +62,9 @@
             &copy; 2000-@DateTime.Now.Year, powered by <b><a href="https://www.axuno.net/" style="text-decoration: none">axuno</a></b>
         </div>
     </footer>
-<script src="@Url.Content(ScriptName.Lib.BootstrapAllJs)"></script>
+<script src="@Url.Content(ScriptName.Lib.BootstrapAllJs)" asp-append-version="true"></script>
 <jl-javascript-logger-definitions request-id="@ViewContext.HttpContext.TraceIdentifier" />
-    <script src="@Url.Content(ScriptName.Lib.JsNLog)"></script>
+<script src="@Url.Content(ScriptName.Lib.JsNLog)" asp-append-version="true"></script>
 @if (IsSectionDefined(SectionName.ScriptStandardSection))
 {@await RenderSectionAsync(SectionName.ScriptStandardSection, false)}
 <environment include="Production"><partial name="_GoogleAnalytics.cshtml" /></environment>


### PR DESCRIPTION
* Set TempusDominus container element to input (was body before)
* Append version number to static css and js files