### PR TITLE
Fix: Purge cache after a CalendarEntity is saved

### DIFF
--- a/TournamentCalendar/Models/Calendar/EditModel.cs
+++ b/TournamentCalendar/Models/Calendar/EditModel.cs
@@ -402,7 +402,7 @@ public class EditModel : CalendarEntity, IValidatableObject
             // Id will be zero if the Guid does not exist:
             Id = await _appDb!.CalendarRepository.GetIdForGuid(Guid, cancellationToken);
 
-            confirmModel.SaveSuccessful = await _appDb.GenericRepository.Save(this, true, cancellationToken);
+            confirmModel.SaveSuccessful = await _appDb.CalendarRepository.Save(this, true, cancellationToken);
             confirmModel.Entity = this;
         }
         catch (Exception ex)

--- a/TournamentCalendar/Models/Shared/ApproveModelTournamentCalendar.cs
+++ b/TournamentCalendar/Models/Shared/ApproveModelTournamentCalendar.cs
@@ -69,7 +69,14 @@ public class ApproveModelTournamentCalendar<T> where T : EntityBase2, new()
 
             if (Entity.IsDirty)
             {
-                SaveSuccessFul = await _appDb.CalendarRepository.SaveEntity(Entity, true);
+                if (Entity is not CalendarEntity calendarEntity)
+                {
+                    SaveSuccessFul = await _appDb.GenericRepository.Save(Entity, true, cancellationToken);
+                }
+                else
+                {
+                    SaveSuccessFul = await _appDb.CalendarRepository.Save(calendarEntity, true, cancellationToken);
+                }
             }
             else
             {

--- a/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -62,8 +62,8 @@
 @section MetaSection {<meta name="robots" content="index, follow">}
 @section CssSection {
     <link href="@Url.Content(CssName.Lib.SimpleDataTablesCss)" rel="stylesheet" />
+    @* Styles used in wrappers inserted by simpleDatatables javaScript *@
     <style>
-        @* Styles used in wrappers inserted by simpleDatatables javaScript *@
         .datatable-top {
             padding-left: 0 !important;
             padding-top: .25rem !important;


### PR DESCRIPTION
* CalendarRepository does not inherit from GenericRepository
* Cache is now cleared using a CacheTag and ConnectionString after saving a CalendarEntity