### PR TITLE
Upgrade MailMergeLib to v5.11.0

### DIFF
--- a/TournamentCalendar.Tests/BasicIntegrationTests.cs
+++ b/TournamentCalendar.Tests/BasicIntegrationTests.cs
@@ -52,7 +52,7 @@ public class BasicIntegrationTests
 
     // Tests for (mostly localized) Urls before April 2023
     [TestCase("/kalender")]
-    [TestCase("/kalender/id/1")]
+    [TestCase("/kalender/id/21375")]
     [TestCase("/kalender/eintrag")]
     [TestCase("/volley-news")]
     [TestCase("/info/impressum")]
@@ -62,7 +62,7 @@ public class BasicIntegrationTests
     // Tests for Urls used from April 2023
     [TestCase("/")]
     [TestCase("/calendar")]
-    [TestCase("/calendar/1")]
+    [TestCase("/calendar/21375")]
     [TestCase("/calendar/entry")]
     [TestCase("/calendar/entry/0a98470df3424be2acf75d36dcc08ebd")]
     [TestCase("/volley-news/register")]

--- a/TournamentCalendar/TournamentCalendar.csproj
+++ b/TournamentCalendar/TournamentCalendar.csproj
@@ -39,7 +39,7 @@
 	<ItemGroup>
 		<PackageReference Include="cloudscribe.Web.Navigation" Version="6.0.2" />
 		<PackageReference Include="JSNLog" Version="3.0.1" />
-		<PackageReference Include="MailMergeLib" Version="5.10.0" />
+		<PackageReference Include="MailMergeLib" Version="5.11.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />
 		<PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
@@ -47,7 +47,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
-		<PackageReference Include="NLog.Web.AspNetCore" Version="5.2.2" />
+		<PackageReference Include="NLog.Web.AspNetCore" Version="5.3.0" />
 		<PackageReference Include="StackifyMiddleware" Version="3.0.5.2" />
 		<PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
 	</ItemGroup>


### PR DESCRIPTION
* Update `MailMergeLib` to `v5.11.0`. It references `SmartFormat v3.2.1` which has breaking changes to `v2.7.3`
* Format strings in this project are not affected