### PR TITLE
Prepare for net80 migration, bump version to v3.2.4

### DIFF
--- a/TournamentCalendar.Tests/BasicIntegrationTests.cs
+++ b/TournamentCalendar.Tests/BasicIntegrationTests.cs
@@ -48,7 +48,7 @@ public class BasicIntegrationTests
                     {
                         var dbContext = new DbContext();
                         context.Configuration.Bind(nameof(DbContext), dbContext);
-                        dbContext.ConnectionString = context.Configuration.GetConnectionString(dbContext.ConnectionKey);
+                        dbContext.ConnectionString = context.Configuration.GetConnectionString(dbContext.ConnectionKey)!;
 
                         services.AddSingleton<IDbContext>(dbContext);
                         services.AddScoped<IAppDb>(s => s.GetRequiredService<IDbContext>().AppDb);

--- a/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
+++ b/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
@@ -1,20 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\TournamentCalendar\TournamentCalendar.csproj" />
   </ItemGroup>
-
 </Project>

--- a/TournamentCalendar/Controllers/Calendar.cs
+++ b/TournamentCalendar/Controllers/Calendar.cs
@@ -18,7 +18,7 @@ public class Calendar : ControllerBase
     public Calendar(IWebHostEnvironment hostingEnvironment, IConfiguration configuration, IAppDb appDb, ILogger<Calendar> logger, IMailMergeService mailMergeService) : base(hostingEnvironment, configuration)
     {
         _mailMergeService = mailMergeService;
-        _domainName = configuration["DomainName"];
+        _domainName = configuration["DomainName"]!;
         _appDb = appDb;
         _logger = logger;
     }

--- a/TournamentCalendar/Controllers/Captcha.cs
+++ b/TournamentCalendar/Controllers/Captcha.cs
@@ -25,9 +25,9 @@ public class Captcha : ControllerBase
 
         // Change the response headers to output an un-cached image.
         HttpContext.Response.Clear();
-        HttpContext.Response.Headers.Add("Expires", DateTime.UtcNow.Date.AddDays(-1).ToString("R"));
-        HttpContext.Response.Headers.Add("Cache-Control", "no-store, no-cache, must-revalidate");
-        HttpContext.Response.Headers.Add("Pragma", "no-cache");
+        HttpContext.Response.Headers.Append("Expires", DateTime.UtcNow.Date.AddDays(-1).ToString("R"));
+        HttpContext.Response.Headers.Append("Cache-Control", "no-store, no-cache, must-revalidate");
+        HttpContext.Response.Headers.Append("Pragma", "no-cache");
 
         HttpContext.Response.ContentType = "image/svg+xml";
         return Task.FromResult(Content(ci.Image));

--- a/TournamentCalendar/Controllers/Contact.cs
+++ b/TournamentCalendar/Controllers/Contact.cs
@@ -13,7 +13,7 @@ public class Contact : ControllerBase
 
     public Contact(IWebHostEnvironment hostingEnvironment, IConfiguration configuration, ILogger<Contact> logger, IMailMergeService mailMergeService) : base(hostingEnvironment, configuration)
     {
-        _domainName = configuration["DomainName"];
+        _domainName = configuration["DomainName"]!;
         _mailMergeService = mailMergeService;
         _logger = logger;
     }

--- a/TournamentCalendar/Controllers/ContentSynd.cs
+++ b/TournamentCalendar/Controllers/ContentSynd.cs
@@ -20,8 +20,8 @@ public class ContentSynd : ControllerBase
     public async Task<IActionResult> CalendarList(CancellationToken cancellationToken)
     {
         // Cross Origin Request Sharing (CORS) - allow request from any domain:
-        Response.Headers.Add("Access-Control-Allow-Origin", "*");
-        _logger.LogInformation("Host: {RemoteIp}, Referrer: {Referrer}", GetRemoteIpAddress(), string.IsNullOrEmpty(Request.Headers["Referer"]) ? Request.Headers["Referrer"] : Request.Headers["Referer"]);
+        Response.Headers.Append("Access-Control-Allow-Origin", "*");
+        _logger.LogInformation("Host: {RemoteIp}, Referrer: {Referrer}", GetRemoteIpAddress(), string.IsNullOrEmpty(Request.Headers.Referer) ? Request.Headers["Referrer"] : Request.Headers.Referer);
         var model = new Models.Calendar.BrowseModel(_appDb);
         await model.Load(cancellationToken);
         return PartialView(ViewName.ContentSynd.CalendarListPartial, model);
@@ -30,7 +30,7 @@ public class ContentSynd : ControllerBase
     [HttpGet("calendar.css")]
     public IActionResult CalendarListCss()
     {
-        Response.Headers.Add("Access-Control-Allow-Origin", "*");
+        Response.Headers.Append("Access-Control-Allow-Origin", "*");
         Response.ContentType = "text/css";
         return PartialView(ViewName.ContentSynd.CalendarListPartialCss);
     }
@@ -38,9 +38,9 @@ public class ContentSynd : ControllerBase
     [HttpGet("calendar.js")]
     public IActionResult CalendarListJs()
     {
-        Response.Headers.Add("Access-Control-Allow-Origin", "*");
+        Response.Headers.Append("Access-Control-Allow-Origin", "*");
         Response.ContentType = "text/javascript"; // IE < 9 does not support application/javascript
-        _logger.LogInformation("Host: {Host}, Referrer: {Referrer}", GetRemoteIpAddress(), string.IsNullOrEmpty(Request.Headers["Referer"]) ? Request.Headers["Referrer"] : Request.Headers["Referer"]);
+        _logger.LogInformation("Host: {Host}, Referrer: {Referrer}", GetRemoteIpAddress(), string.IsNullOrEmpty(Request.Headers.Referer) ? Request.Headers["Referrer"] : Request.Headers.Referer);
         return PartialView(ViewName.ContentSynd.CalendarListPartialJs);
     }
 

--- a/TournamentCalendar/Controllers/InfoService.cs
+++ b/TournamentCalendar/Controllers/InfoService.cs
@@ -18,7 +18,7 @@ public class InfoService : ControllerBase
     public InfoService(IAppDb appDb, IWebHostEnvironment hostingEnvironment, IConfiguration configuration, ILogger<InfoService> logger, IMailMergeService mailMergeService) : base(hostingEnvironment, configuration)
     {
         _appDb = appDb;
-        _domainName = configuration["DomainName"];
+        _domainName = configuration["DomainName"]!;
         _mailMergeService = mailMergeService;
         _logger = logger;
     }

--- a/TournamentCalendar/TournamentCalendar.csproj
+++ b/TournamentCalendar/TournamentCalendar.csproj
@@ -1,172 +1,157 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
-	<PropertyGroup>
-        <Product>TournamentCalendar</Product>
-        <TargetFramework>net6.0</TargetFramework>
-        <Version>3.2.3</Version>
-        <FileVersion>3.2.3</FileVersion>
-        <EnableDefaultContentItems>true</EnableDefaultContentItems>
-        <Authors>axuno gGmbH</Authors>
-        <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-        <Copyright>Copyright 1998-$(CurrentYear) $(Authors)</Copyright>
-        <LangVersion>latest</LangVersion>
-        <Nullable>enable</Nullable>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageIcon>TournamentCalender-192x192.png</PackageIcon>
-        <AssemblyVersion>3.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
-        <LangVersion>latest</LangVersion>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <AnalysisLevel>latest</AnalysisLevel>
-        <Features>strict</Features>
-        <!-- With dotnet, add parameter: -p:SatelliteResourceLanguages="""en;de""" -->
-        <SatelliteResourceLanguages>en;de</SatelliteResourceLanguages>
-        <ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-		<WarningsAsErrors>NU1605</WarningsAsErrors>
-	</PropertyGroup>
-
-    
-    <ItemGroup>
-        <Using Include="System.Globalization" />
-        <Using Include="Microsoft.AspNetCore.Authorization" />
-        <Using Include="Microsoft.AspNetCore.Builder" />
-        <Using Include="Microsoft.AspNetCore.Hosting" />
-        <Using Include="Microsoft.AspNetCore.Hosting" />
-        <Using Include="Microsoft.AspNetCore.Http" />
-        <Using Include="Microsoft.AspNetCore.Identity" />
-        <Using Include="Microsoft.AspNetCore.Localization" />
-        <Using Include="Microsoft.AspNetCore.Mvc" />
-        <Using Include="Microsoft.AspNetCore.Mvc.Localization" />
-        <Using Include="Microsoft.AspNetCore.Routing" />
-        <Using Include="Microsoft.Extensions.Configuration" />
-        <Using Include="Microsoft.Extensions.DependencyInjection" />
-        <Using Include="Microsoft.Extensions.Hosting" />
-        <Using Include="Microsoft.Extensions.Localization" />
-        <Using Include="Microsoft.Extensions.Logging" />
-        <Using Include="Microsoft.Extensions.Options" />
-    </ItemGroup>
-
-	<ItemGroup>
-		<None Include="TournamentCalender-192x192.png">
-		  <Pack>True</Pack>
-		  <PackagePath></PackagePath>
-		</None>
-	</ItemGroup>
-
-    <ItemGroup>
-        <InternalsVisibleTo Include="TournamentCalendar.Tests" />
-    </ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="cloudscribe.Web.Navigation" Version="6.0.2" />
-		<PackageReference Include="JSNLog" Version="3.0.1" />
-		<PackageReference Include="MailMergeLib" Version="5.11.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.19" />
-		<PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.14" />
-		<PackageReference Include="NLog.Web.AspNetCore" Version="5.3.2" />
-		<PackageReference Include="StackifyMiddleware" Version="3.0.5.2" />
-		<PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<EmbeddedResource Update="Models\Error\StatusCodes.de.resx">
-		  <Generator></Generator>
-		</EmbeddedResource>
-		<EmbeddedResource Update="Models\Error\StatusCodes.resx">
-		  <Generator>PublicResXFileCodeGenerator</Generator>
-		  <LastGenOutput>StatusCodes.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="Models\Error\StatusDescriptions.resx">
-		  <Generator>PublicResXFileCodeGenerator</Generator>
-		  <LastGenOutput>StatusDescriptions.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="Resources\DataAnnotationResource.de.resx">
-			<Generator></Generator>
-		</EmbeddedResource>
-		<EmbeddedResource Update="Resources\DataAnnotationResource.resx">
-			<LastGenOutput>DataAnnotationResource.Designer.cs</LastGenOutput>
-			<Generator>PublicResXFileCodeGenerator</Generator>
-		</EmbeddedResource>
-		<EmbeddedResource Update="Resources\ModelBindingMessageResource.de.resx">
-			<Generator></Generator>
-		</EmbeddedResource>
-		<EmbeddedResource Update="Resources\ModelBindingMessageResource.resx">
-			<Generator>PublicResXFileCodeGenerator</Generator>
-			<LastGenOutput>ModelBindingMessageResource.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="Views\ContentSynd\CalendarListPartialCss.cshtml" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Compile Update="Models\Error\StatusCodes.Designer.cs">
-		  <DesignTime>True</DesignTime>
-		  <AutoGen>True</AutoGen>
-		  <DependentUpon>StatusCodes.resx</DependentUpon>
-		</Compile>
-		<Compile Update="Models\Error\StatusDescriptions.Designer.cs">
-		  <DesignTime>True</DesignTime>
-		  <AutoGen>True</AutoGen>
-		  <DependentUpon>StatusDescriptions.resx</DependentUpon>
-		</Compile>
-		<Compile Update="Resources\DataAnnotationResource.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>DataAnnotationResource.resx</DependentUpon>
-		</Compile>
-		<Compile Update="Resources\ModelBindingMessageResource.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ModelBindingMessageResource.resx</DependentUpon>
-		</Compile>
-	</ItemGroup>
-
-	<ItemGroup>
-		<Content Update="Configuration\*" CopyToPublishDirectory="Always" />
-        <Content Remove="wwwroot\Collect\*.xml" />
-        <None Update="MailStore\**" CopyToPublishDirectory="Always" />
-        <Folder Remove="logs\" />
-        <Folder Remove="Scripts\" />
-        <Content Remove="Scripts\**" CopyToPublishDirectory="Never" />
-        <Folder Include="wwwroot\js\" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\Data\TournamentCalender.Data.csproj" />
-	</ItemGroup>
-
-	<!-- Custom PropertyGroup to add the Environment name during publish. The EnvironmentName property is used for the 'Environment' variable in web.config when publishing. -->
-	<PropertyGroup Condition=" '$(Configuration)' == '' Or '$(Configuration)' == 'Debug'">
-		<EnvironmentName>Development</EnvironmentName>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)' != '' AND '$(Configuration)' != 'Debug' ">
-		<EnvironmentName>Production</EnvironmentName>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-		<TypeScriptTarget>ES5</TypeScriptTarget>
-		<TypeScriptJSXEmit>React</TypeScriptJSXEmit>
-		<TypeScriptModuleKind>AMD</TypeScriptModuleKind>
-		<TypeScriptCompileOnSaveEnabled>True</TypeScriptCompileOnSaveEnabled>
-		<TypeScriptNoImplicitAny>False</TypeScriptNoImplicitAny>
-		<TypeScriptRemoveComments>False</TypeScriptRemoveComments>
-		<TypeScriptOutFile />
-		<TypeScriptOutDir />
-		<TypeScriptGeneratesDeclarations>False</TypeScriptGeneratesDeclarations>
-		<TypeScriptNoEmitOnError>True</TypeScriptNoEmitOnError>
-		<TypeScriptSourceMap>True</TypeScriptSourceMap>
-		<TypeScriptMapRoot />
-		<TypeScriptSourceRoot />
-	</PropertyGroup>
-
+  <PropertyGroup>
+    <Product>TournamentCalendar</Product>
+    <TargetFramework>net6.0</TargetFramework>
+    <Version>3.2.4</Version>
+    <FileVersion>3.2.4</FileVersion>
+    <EnableDefaultContentItems>true</EnableDefaultContentItems>
+    <Authors>axuno gGmbH</Authors>
+    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+    <Copyright>Copyright 1998-$(CurrentYear) $(Authors)</Copyright>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>TournamentCalender-192x192.png</PackageIcon>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion><!--only update AssemblyVersion with major releases -->
+    <LangVersion>latest</LangVersion>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <Features>strict</Features>
+    <!-- With dotnet, add parameter: -p:SatelliteResourceLanguages="""en;de""" -->
+    <SatelliteResourceLanguages>en;de</SatelliteResourceLanguages>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors>NU1605</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Using Include="System.Globalization" />
+    <Using Include="Microsoft.AspNetCore.Authorization" />
+    <Using Include="Microsoft.AspNetCore.Builder" />
+    <Using Include="Microsoft.AspNetCore.Hosting" />
+    <Using Include="Microsoft.AspNetCore.Hosting" />
+    <Using Include="Microsoft.AspNetCore.Http" />
+    <Using Include="Microsoft.AspNetCore.Identity" />
+    <Using Include="Microsoft.AspNetCore.Localization" />
+    <Using Include="Microsoft.AspNetCore.Mvc" />
+    <Using Include="Microsoft.AspNetCore.Mvc.Localization" />
+    <Using Include="Microsoft.AspNetCore.Routing" />
+    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.Hosting" />
+    <Using Include="Microsoft.Extensions.Localization" />
+    <Using Include="Microsoft.Extensions.Logging" />
+    <Using Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TournamentCalender-192x192.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="TournamentCalendar.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="cloudscribe.Web.Navigation" Version="6.0.3" />
+    <PackageReference Include="JSNLog" Version="3.0.2" />
+    <PackageReference Include="MailMergeLib" Version="5.11.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.25" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.16" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.7" />
+    <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Models\Error\StatusCodes.de.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Models\Error\StatusCodes.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>StatusCodes.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Models\Error\StatusDescriptions.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>StatusDescriptions.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\DataAnnotationResource.de.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\DataAnnotationResource.resx">
+      <LastGenOutput>DataAnnotationResource.Designer.cs</LastGenOutput>
+      <Generator>PublicResXFileCodeGenerator</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\ModelBindingMessageResource.de.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\ModelBindingMessageResource.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>ModelBindingMessageResource.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Views\ContentSynd\CalendarListPartialCss.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Models\Error\StatusCodes.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>StatusCodes.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Models\Error\StatusDescriptions.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>StatusDescriptions.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources\DataAnnotationResource.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataAnnotationResource.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources\ModelBindingMessageResource.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ModelBindingMessageResource.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="Configuration\*" CopyToPublishDirectory="Always" />
+    <Content Remove="wwwroot\Collect\*.xml" />
+    <None Update="MailStore\**" CopyToPublishDirectory="Always" />
+    <Folder Remove="logs\" />
+    <Folder Remove="Scripts\" />
+    <Content Remove="Scripts\**" CopyToPublishDirectory="Never" />
+    <Folder Include="wwwroot\js\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Data\TournamentCalender.Data.csproj" />
+  </ItemGroup>
+  <!-- Custom PropertyGroup to add the Environment name during publish. The EnvironmentName property is used for the 'Environment' variable in web.config when publishing. -->
+  <PropertyGroup Condition=" '$(Configuration)' == '' Or '$(Configuration)' == 'Debug'">
+    <EnvironmentName>Development</EnvironmentName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' != '' AND '$(Configuration)' != 'Debug' ">
+    <EnvironmentName>Production</EnvironmentName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <TypeScriptTarget>ES5</TypeScriptTarget>
+    <TypeScriptJSXEmit>React</TypeScriptJSXEmit>
+    <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
+    <TypeScriptCompileOnSaveEnabled>True</TypeScriptCompileOnSaveEnabled>
+    <TypeScriptNoImplicitAny>False</TypeScriptNoImplicitAny>
+    <TypeScriptRemoveComments>False</TypeScriptRemoveComments>
+    <TypeScriptOutFile />
+    <TypeScriptOutDir />
+    <TypeScriptGeneratesDeclarations>False</TypeScriptGeneratesDeclarations>
+    <TypeScriptNoEmitOnError>True</TypeScriptNoEmitOnError>
+    <TypeScriptSourceMap>True</TypeScriptSourceMap>
+    <TypeScriptMapRoot />
+    <TypeScriptSourceRoot />
+  </PropertyGroup>
 </Project>

--- a/TournamentCalendar/WebAppStartup.cs
+++ b/TournamentCalendar/WebAppStartup.cs
@@ -122,7 +122,7 @@ public static class WebAppStartup
 
         var dbContext = new DbContext();
         context.Configuration.Bind(nameof(DbContext), dbContext);
-        dbContext.ConnectionString = context.Configuration.GetConnectionString(dbContext.ConnectionKey);
+        dbContext.ConnectionString = context.Configuration.GetConnectionString(dbContext.ConnectionKey)!;
 
         ConfigureLlblgenPro(dbContext, context.HostingEnvironment);
         
@@ -139,7 +139,7 @@ public static class WebAppStartup
         // ~/Views/Shared/NavigationNodeSideNavPartial.cshtml
         // ~/Views/Shared/Components/Navigation/*.cshtml
         // ~/Views/_ViewImports.cshtml: @using cloudscribe.Web.Navigation
-        services.AddCloudscribeNavigation(context.Configuration.GetSection("NavigationOptions")); //.Configure<NavigationOptions>(o => o.NavigationMapXmlFileName = ConfigurationFolder + @"\Navigation.xml");
+        services.AddCloudscribeNavigation(context.Configuration.GetSection("NavigationOptions")!); //.Configure<NavigationOptions>(o => o.NavigationMapXmlFileName = ConfigurationFolder + @"\Navigation.xml");
 
         #endregion
 


### PR DESCRIPTION
* Update package references
* Fix nullability warnings for configuration data
* Use HttpContext.Response.Headers.Append instead of HttpContext.Response.Headers.Add

_Note: No errors or warnings left after net80 migration trial. Compilation and first test run successful._