### PR TITLE
Add distance from user location to venue

### DIFF
--- a/Src/TournamentCalendar/Configuration/Navigation.config
+++ b/Src/TournamentCalendar/Configuration/Navigation.config
@@ -12,7 +12,7 @@
                 <NavNode key="AddTournament" controller="Calendar" action="NewEntry" text="Turnier eintragen" preservedRouteParameters="">
                     <Children />
                 </NavNode>
-	            <NavNode key="GeoLocation" controller="GeoLocation" action="Index" text="Entfernung anzeigen" preservedRouteParameters="">
+	            <NavNode key="GeoLocation" controller="GeoLocation" action="Index" text="Entfernungen anzeigen" preservedRouteParameters="">
 		            <Children />
 	            </NavNode>
                 <NavNode key="AboutUs" controller="Calendar" action="Integrate" text="In eigene Homepage integrieren">  

--- a/Src/TournamentCalendar/Configuration/Navigation.config
+++ b/Src/TournamentCalendar/Configuration/Navigation.config
@@ -12,6 +12,9 @@
                 <NavNode key="AddTournament" controller="Calendar" action="NewEntry" text="Turnier eintragen" preservedRouteParameters="">
                     <Children />
                 </NavNode>
+	            <NavNode key="GeoLocation" controller="GeoLocation" action="Index" text="Entfernung anzeigen" preservedRouteParameters="">
+		            <Children />
+	            </NavNode>
                 <NavNode key="AboutUs" controller="Calendar" action="Integrate" text="In eigene Homepage integrieren">  
                     <Children />
                 </NavNode>

--- a/Src/TournamentCalendar/Controllers/Admin.cs
+++ b/Src/TournamentCalendar/Controllers/Admin.cs
@@ -6,9 +6,9 @@ namespace TournamentCalendar.Controllers;
 [Route(nameof(Admin))]
 public class Admin : ControllerBase
 {
-    private readonly Microsoft.Extensions.Hosting.IHostApplicationLifetime _applicationLifetime;
+    private readonly IHostApplicationLifetime _applicationLifetime;
 
-    public Admin(Microsoft.Extensions.Hosting.IHostApplicationLifetime appLifetime)
+    public Admin(IHostApplicationLifetime appLifetime)
     {
         _applicationLifetime = appLifetime;
     }

--- a/Src/TournamentCalendar/Controllers/Auth.cs
+++ b/Src/TournamentCalendar/Controllers/Auth.cs
@@ -3,13 +3,14 @@ using System.Text;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using TournamentCalendar.Models.AccountViewModels;
+using TournamentCalendar.Services;
 using TournamentCalendar.Views;
 
 namespace TournamentCalendar.Controllers;
 
 public class Auth : ControllerBase
 {
-    public readonly IConfiguration _configuration;
+    private readonly IConfiguration _configuration;
 
     public Auth(IConfiguration configuration)
     {

--- a/Src/TournamentCalendar/Controllers/Calendar.cs
+++ b/Src/TournamentCalendar/Controllers/Calendar.cs
@@ -142,7 +142,7 @@ public class Calendar : ControllerBase
         Configuration.Bind(nameof(GoogleConfiguration), googleApi);
         await model.TryGetLongitudeLatitude(googleApi);
         model.Normalize();
-        if (model.IsNew && User.Identity != null && User.Identity.IsAuthenticated)
+        if (model.IsNew && User.Identity is { IsAuthenticated: true })
         {
             model.CreatedByUser = User.Identity.Name;
         }

--- a/Src/TournamentCalendar/Controllers/ContentSynd.cs
+++ b/Src/TournamentCalendar/Controllers/ContentSynd.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Primitives;
 using TournamentCalendar.Data;
+using TournamentCalendar.Services;
 using TournamentCalendar.Views;
 
 namespace TournamentCalendar.Controllers;
@@ -28,7 +29,7 @@ public class ContentSynd : ControllerBase
         // Cross Origin Request Sharing (CORS) - allow request from any domain:
         Response.Headers.Append("Access-Control-Allow-Origin", "*");
         _logger.LogInformation("Host: {RemoteIp}, Referrer: {Referrer}", GetRemoteIpAddress(xForwardedFor, remoteAddr), referrer);
-        var model = new Models.Calendar.BrowseModel(_appDb);
+        var model = new Models.Calendar.BrowseModel(_appDb, new UserLocation(null, null));
         await model.Load(cancellationToken);
         return PartialView(ViewName.ContentSynd.CalendarListPartial, model);
     }

--- a/Src/TournamentCalendar/Controllers/GeoLocation.cs
+++ b/Src/TournamentCalendar/Controllers/GeoLocation.cs
@@ -30,6 +30,10 @@ public class GeoLocation : ControllerBase
         return View(ViewName.GeoLocation.Index);
     }
 
+    /// <summary>
+    /// Sets the location from a user's GUID.
+    /// </summary>
+    /// <param name="guid"></param>
     [HttpGet("location/{guid}")]
     public IActionResult Location(Guid guid)
     {

--- a/Src/TournamentCalendar/Controllers/GeoLocation.cs
+++ b/Src/TournamentCalendar/Controllers/GeoLocation.cs
@@ -1,0 +1,71 @@
+﻿using TournamentCalendar.Services;
+using TournamentCalendar.Views;
+
+namespace TournamentCalendar.Controllers;
+
+/// <summary>
+/// The GeoLocation controller is responsible for handling the user's location.
+/// </summary>
+[Route(nameof(GeoLocation))]
+public class GeoLocation : ControllerBase
+{
+    private readonly IConfiguration _configuration;
+    private readonly UserLocationService _locationService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoLocation"/> class.
+    /// </summary>
+    /// <param name="locationService"></param>
+    /// <param name="configuration"></param>
+    public GeoLocation(UserLocationService locationService, IConfiguration configuration)
+    {
+        _locationService = locationService;
+        _configuration = configuration;
+    }
+
+    [HttpGet("")]
+    public IActionResult Index()
+    {
+        ViewBag.TitleTagText = "Entfernung anzeigen";
+        return View(ViewName.GeoLocation.Index);
+    }
+
+    [HttpGet("location/{guid}")]
+    public IActionResult Location(Guid guid)
+    {
+        if (!ModelState.IsValid)
+            return RedirectToAction(nameof(Calendar.All), nameof(Controllers.Calendar));
+
+        _locationService.SetFromUserGuid(guid);
+
+        return RedirectToAction(nameof(Calendar.All), nameof(Controllers.Calendar));
+    }
+
+    [HttpGet("location/{latitude}/{longitude}")]
+    public IActionResult Location(double latitude, double longitude)
+    {
+        if (!ModelState.IsValid)
+            _locationService.ClearGeoLocation();
+
+        _locationService.SetGeoLocation(latitude, longitude);
+
+        return NoContent();
+    }
+
+    [HttpGet("clear")]
+    public IActionResult ClearLocation()
+    {
+        _locationService.ClearGeoLocation();
+        return NoContent();
+    }
+
+    private IActionResult RedirectToLocal(string returnUrl)
+    {
+        if (Url.IsLocalUrl(returnUrl))
+        {
+            return Redirect(returnUrl);
+        }
+
+        return RedirectToAction(nameof(Calendar.All), nameof(Controllers.Calendar));
+    }
+}

--- a/Src/TournamentCalendar/Controllers/InfoService.cs
+++ b/Src/TournamentCalendar/Controllers/InfoService.cs
@@ -111,7 +111,8 @@ public class InfoService : ControllerBase
         {
             HttpContext.Session.Remove(Axuno.Web.CaptchaSvgGenerator.CaptchaSessionKeyName);
 
-            if (!(confirmationModel = await model.Save(cancellationToken)).SaveSuccessful)
+            confirmationModel = await model.Save(cancellationToken);
+            if (!confirmationModel.SaveSuccessful)
                 return View(ViewName.InfoService.Confirm, confirmationModel);
 
             if (confirmationModel.Entity?.UnSubscribedOn == null)

--- a/Src/TournamentCalendar/Controllers/InfoService.cs
+++ b/Src/TournamentCalendar/Controllers/InfoService.cs
@@ -72,10 +72,11 @@ public class InfoService : ControllerBase
     [HttpPost(nameof(InfoService.Entry)), ValidateAntiForgeryToken]
     public async Task<IActionResult> Entry([FromForm] Models.InfoService.EditModel model, CancellationToken cancellationToken)
     {
+        ViewBag.TitleTagText = "Volley-News abonnieren";
+
         model.SetAppDb(_appDb);
         _ = await TryUpdateModelAsync(model);
-
-        ViewBag.TitleTagText = "Volley-News abonnieren";
+        
         model.EditMode = string.IsNullOrWhiteSpace(model.Guid) ? Models.InfoService.EditMode.New : Models.InfoService.EditMode.Change;
 
         if (!ModelState.IsValid && model.ExistingEntryWithSameEmail is { ConfirmedOn: null })

--- a/Src/TournamentCalendar/Controllers/Newsletter.cs
+++ b/Src/TournamentCalendar/Controllers/Newsletter.cs
@@ -1,5 +1,6 @@
 ﻿using TournamentCalendar.Data;
 using TournamentCalendar.Models.Newsletter;
+using TournamentCalendar.Services;
 
 namespace TournamentCalendar.Controllers;
 
@@ -7,16 +8,18 @@ namespace TournamentCalendar.Controllers;
 public class Newsletter : ControllerBase
 {
     private readonly IAppDb _appDb;
+    private readonly UserLocation _userLocation;
 
-    public Newsletter(IAppDb appDb)
+    public Newsletter(IAppDb appDb, UserLocationService locationService)
     {
         _appDb = appDb;
+        _userLocation = locationService.GetLocation();
     }
 
     [HttpGet("show")]
     public async Task<IActionResult> Show(CancellationToken cancellationToken)
     {
-        var model = await new NewsletterModel(_appDb).InitializeAndLoad(cancellationToken);
+        var model = await new NewsletterModel(_appDb, _userLocation).InitializeAndLoad(cancellationToken);
 
         return View("Show", model);
     }

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Angle.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Angle.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace Axuno.Tools.GeoSpatial;
 
@@ -389,7 +388,7 @@ public class Angle : IComparable<Angle>, IEquatable<Angle>, IFormattable
             numberFormat = provider.GetFormat(typeof(NumberFormatInfo)) as NumberFormatInfo;
         }
 
-        return numberFormat ?? CultureInfo.CurrentUICulture.NumberFormat;            
+        return numberFormat ?? CultureInfo.CurrentUICulture.NumberFormat;
     }
 
     /// <summary>

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/GoogleGeo.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/GoogleGeo.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Globalization;
-using System.Net.Http;
+﻿using System.Globalization;
 using System.Net.Http.Headers;
-using System.Threading.Tasks;
 using System.Web;
 using System.Xml;
 
@@ -148,7 +145,7 @@ public class GoogleGeo
         switch (geoResponse.StatusText)
         {
             case null:
-                throw new Exception($"XML node {statusNode} not found");
+                throw new InvalidOperationException($"XML node {statusNode} not found");
             case "OK":
                 geoResponse.Found = true;
                 geoResponse.Success = true;
@@ -182,7 +179,7 @@ public class GoogleGeo
 
         if (latNode == null || lngNode == null || locTypeNode == null)
         {
-            throw new Exception("XML child nodes in /GeocodeResponse/result/geometry not found");
+            throw new InvalidOperationException("XML child nodes in /GeocodeResponse/result/geometry not found");
         }
 
         switch (locTypeNode.InnerText)

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Location.Parser.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Location.Parser.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Axuno.Tools.GeoSpatial;
 

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Location.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Location.cs
@@ -201,7 +201,7 @@ public sealed partial class Location : IEquatable<Location>, IFormattable, IXmlS
 
     /// <summary>
     ///     Calculates the great circle distance, in meters, between this instance
-    ///     and the specified value.
+    ///     and the specified value, using the Haversine formula.
     /// </summary>
     /// <param name="point">The location of the other point.</param>
     /// <returns>The great circle distance, in meters.</returns>

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Location.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Location.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Globalization;
+using System.Text;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/LocationCollection.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/LocationCollection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Xml;

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/LocationStyles.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/LocationStyles.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Axuno.Tools.GeoSpatial;
+﻿namespace Axuno.Tools.GeoSpatial;
 
 /// <summary>
 /// Determines the styles permitted in string arguments that are passed

--- a/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Longitude.cs
+++ b/Src/TournamentCalendar/Library/Axuno.Tools/GeoSpatial/Longitude.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace Axuno.Tools.GeoSpatial;
 

--- a/Src/TournamentCalendar/Models/Calendar/BrowseModel.cs
+++ b/Src/TournamentCalendar/Models/Calendar/BrowseModel.cs
@@ -1,4 +1,5 @@
 ﻿using TournamentCalendar.Data;
+using TournamentCalendar.Services;
 using TournamentCalendarDAL.EntityClasses;
 using TournamentCalendarDAL.HelperClasses;
 
@@ -10,10 +11,12 @@ public class BrowseModel
     private readonly EntityCollection<CalendarEntity> _tournaments = new();
     private readonly EntityCollection<SurfaceEntity> _surfaces = new();
     private readonly EntityCollection<PlayingAbilityEntity> _playingAbilities = new();
+    private readonly UserLocation _userLocation;
 
-    public BrowseModel(IAppDb appDb)
+    public BrowseModel(IAppDb appDb, UserLocation userLocation)
     {
         _appDb = appDb;
+        _userLocation = userLocation;
     }
 
     public async Task Load(CancellationToken cancellationToken)
@@ -50,5 +53,10 @@ public class BrowseModel
     public int Count => _tournaments.Count;
 
     public IEnumerable<CalendarEntityDisplayModel> DisplayModel =>
-        _tournaments.Select(t => new CalendarEntityDisplayModel(t, _surfaces, _playingAbilities));
+        _tournaments.Select(t => new CalendarEntityDisplayModel(t, _userLocation, _surfaces, _playingAbilities));
+
+    public bool IsGeoSpacial()
+    {
+        return DisplayModel.Any(m => m.IsGeoSpatial());
+    }
 }

--- a/Src/TournamentCalendar/Models/Calendar/CalendarEntityDisplayModel.cs
+++ b/Src/TournamentCalendar/Models/Calendar/CalendarEntityDisplayModel.cs
@@ -7,6 +7,7 @@ namespace TournamentCalendar.Models.Calendar;
 
 public class CalendarEntityDisplayModel : CalendarEntity
 {
+    private const string LatLonFormat = "###.########";
     private readonly ICollection<SurfaceEntity> _surfaces;
     private readonly ICollection<PlayingAbilityEntity> _playingAbilities;
     private readonly UserLocation _userLocation;
@@ -132,15 +133,15 @@ public class CalendarEntityDisplayModel : CalendarEntity
         if (_userLocation.IsSet)
         {
             return string.Format("https://maps.google.de/maps?saddr={0},{1}&daddr={2},{3}",
-                _userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture),
-                _userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture),
-                Latitude.Value.ToString("###.########", CultureInfo.InvariantCulture),
-                Longitude.Value.ToString("###.########", CultureInfo.InvariantCulture));
+                _userLocation.Latitude!.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture),
+                _userLocation.Longitude!.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture),
+                Latitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture),
+                Longitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture));
         }
 
         return string.Format("https://maps.google.de?q={0},{1}",
-            Latitude.Value.ToString("###.########", CultureInfo.InvariantCulture),
-            Longitude.Value.ToString("###.########", CultureInfo.InvariantCulture));
+            Latitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture),
+            Longitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture));
     }
 
     public bool IsGeoSpatial()

--- a/Src/TournamentCalendar/Models/Calendar/EditModel.cs
+++ b/Src/TournamentCalendar/Models/Calendar/EditModel.cs
@@ -60,7 +60,7 @@ public class EditModel : CalendarEntity, IValidatableObject
 
     public async Task<bool> TryGetLongitudeLatitude(GoogleConfiguration googleConfig)
     {
-        if (Fields[CalendarFields.Street.FieldIndex].IsChanged || Fields[CalendarFields.PostalCode.FieldIndex].IsChanged || Fields[CalendarFields.City.FieldIndex].IsChanged)
+        if ((Latitude is null || Longitude is null) || Fields[CalendarFields.Street.FieldIndex].IsChanged || Fields[CalendarFields.PostalCode.FieldIndex].IsChanged || Fields[CalendarFields.City.FieldIndex].IsChanged)
         {
             try
             {
@@ -261,7 +261,7 @@ public class EditModel : CalendarEntity, IValidatableObject
             else
             {
                 // Set deletion date, if tournament shall not be displayed
-                base.DeletedOn = value ? DateTime.Now : null;
+                base.DeletedOn = value ? null : DateTime.Now;
             }
         }
     }

--- a/Src/TournamentCalendar/Models/GeoLocation/EditModel.cs
+++ b/Src/TournamentCalendar/Models/GeoLocation/EditModel.cs
@@ -1,0 +1,81 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using TournamentCalendar.Data;
+using TournamentCalendar.Library;
+using TournamentCalendar.Services;
+using TournamentCalendarDAL.EntityClasses;
+using TournamentCalendarDAL.HelperClasses;
+
+namespace TournamentCalendar.Models.GeoLocation;
+
+public class EditModel : IValidatableObject
+{
+    private IAppDb? _appDb;
+    private readonly string[] _countryIds = new[] { "DE", "AT", "CH", "LI", "IT", "NL", "BE", "LU", "FR", "PL", "DK", "CZ", "SK" };
+
+    [Display(Name = "Land")]
+    public string? CountryId { get; set; }
+
+    [Display(Name = "Postleitzahl")]
+    public string? ZipCode { get; set; }
+
+    [Display(Name = "Ort")]
+    public string? City { get; set; }
+
+    [Display(Name = "Straße")]
+    public string? Street { get; set; }
+
+    public void SetAppDb(IAppDb appDb)
+    {
+        _appDb = appDb;
+    }
+
+    public async Task<IEnumerable<SelectListItem>> GetCountriesList()
+    {
+        var countries = new EntityCollection<CountryEntity>();
+        await _appDb!.CountriesRepository.GetCountriesList(countries, _countryIds, CancellationToken.None);
+
+        // add to countries list in the sequence of countryIds array
+        return _countryIds.Select(id => countries.First(c => c.Id == id)).Select(
+            item => new SelectListItem { Value = item.Id, Text = item.Name }).ToList();
+    }
+
+    public async Task<UserLocation> TryGetLongitudeLatitude(GoogleConfiguration googleConfig)
+    {
+        try
+        {
+            // try to get longitude and latitude by Google Maps API
+            var completeAddress = string.Join(", ", ZipCode, City, Street);
+            CountryId ??= "DE";
+
+            var location = await Axuno.Tools.GeoSpatial.GoogleGeo.GetLocation(CountryId, completeAddress,
+                googleConfig.ServiceApiKey, TimeSpan.FromSeconds(15));
+            if (location.GeoLocation.Latitude != null && location.GeoLocation.Latitude.Degrees > 1 &&
+                location.GeoLocation.Longitude?.Degrees > 1)
+            {
+                return new UserLocation(location.GeoLocation.Latitude.TotalDegrees,
+                    location.GeoLocation.Longitude.TotalDegrees);
+            }
+        }
+        catch (Exception)
+        {
+            // ignored
+        }
+
+        return new UserLocation(null, null);
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        // Will be called only after individual fields are valid
+        var errors = new List<ValidationResult>();
+
+        if (CountryId == null || !_countryIds.ToList().Contains(CountryId))
+            errors.Add(new ValidationResult("'Land' aus der Liste ist erforderlich", new[] {nameof(CountryId)}));
+
+        if (string.IsNullOrEmpty(ZipCode) && string.IsNullOrEmpty(City))
+            errors.Add(new ValidationResult("'Postleitzahl' oder 'Ort' sind erforderlich", new[] { nameof(ZipCode), nameof(City) }));
+
+        return errors;
+    }
+}

--- a/Src/TournamentCalendar/Models/InfoService/EditModel.cs
+++ b/Src/TournamentCalendar/Models/InfoService/EditModel.cs
@@ -172,10 +172,7 @@ public class EditModel : InfoServiceEntity, IValidatableObject
         }
         else
         {
-            CountryId = null;
-            ZipCode = City = Street = string.Empty;
-            Longitude = Latitude = null;
-            MaxDistance = null;
+            MaxDistance = 6300;
         }
 
         // if the email address is changed, it must be re-confirmed

--- a/Src/TournamentCalendar/Models/InfoService/EditModel.cs
+++ b/Src/TournamentCalendar/Models/InfoService/EditModel.cs
@@ -302,14 +302,10 @@ public class EditModel : InfoServiceEntity, IValidatableObject
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public sealed class ValidateAddressFieldsAttribute : ValidationAttribute
 {
-    private readonly string[] _addressFieldNames;
-
     public ValidateAddressFieldsAttribute(string addressFieldNames)
     {
         if (addressFieldNames == null)
             throw new ArgumentNullException(nameof(addressFieldNames));
-
-        _addressFieldNames = addressFieldNames.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
     }
 
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)

--- a/Src/TournamentCalendar/Models/Newsletter/NewsletterModel.cs
+++ b/Src/TournamentCalendar/Models/Newsletter/NewsletterModel.cs
@@ -3,6 +3,7 @@ using TournamentCalendar.Models.Calendar;
 using TournamentCalendarDAL.EntityClasses;
 using TournamentCalendarDAL.HelperClasses;
 using MailMergeLib;
+using TournamentCalendar.Services;
 
 namespace TournamentCalendar.Models.Newsletter;
 
@@ -12,10 +13,12 @@ public class NewsletterModel
     private readonly EntityCollection<CalendarEntity> _tournaments = new();
     private readonly EntityCollection<SurfaceEntity> _surfaces = new();
     private readonly EntityCollection<PlayingAbilityEntity> _playingAbilities = new();
+    private readonly UserLocation _userLocation;
 
-    public NewsletterModel(IAppDb appDb)
+    public NewsletterModel(IAppDb appDb, UserLocation userLocation)
     {
         _appDb = appDb;
+        _userLocation = userLocation;
     }
 
     public async Task<NewsletterModel> InitializeAndLoad(CancellationToken cancellationToken)
@@ -61,7 +64,7 @@ public class NewsletterModel
 
     public ICollection<CalendarEntityDisplayModel> GetCalendarDisplayModel() =>
         _tournaments
-            .Select(t => new CalendarEntityDisplayModel(t, _surfaces, _playingAbilities)).ToList();
+            .Select(t => new CalendarEntityDisplayModel(t, _userLocation, _surfaces, _playingAbilities)).ToList();
 
     public DateTime LastSendDate { get; private set; }
 

--- a/Src/TournamentCalendar/Services/CookieService.cs
+++ b/Src/TournamentCalendar/Services/CookieService.cs
@@ -45,9 +45,9 @@ public class CookieService : ICookieService
     /// </summary>
     /// <param name="cookieName"></param>
     /// <param name="cookieValue"></param>
-    /// <param name="expireTime"></param>
+    /// <param name="expireTime">if <see langword="null"/>, 1 year is used as default</param>
     /// <returns><see langword="true"/> if the cookie could be set.</returns>
-    public bool SetCookieValue(string cookieName, string cookieValue, TimeSpan? expireTime = null)
+    public bool SetCookieValue(string cookieName, string cookieValue, TimeSpan? expireTime)
     {
         if (!EnsureHttpContext())
         {

--- a/Src/TournamentCalendar/Services/CookieService.cs
+++ b/Src/TournamentCalendar/Services/CookieService.cs
@@ -1,0 +1,89 @@
+﻿namespace TournamentCalendar.Services;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// This service provides methods to get, set and remove cookies.
+/// </summary>
+public class CookieService : ICookieService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<CookieService> _logger;
+
+    public const string LocationCookieName = ".tc.loc";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CookieService"/> class.
+    /// Register as a scoped service.
+    /// </summary>
+    /// <param name="httpContextAccessor"></param>
+    /// <param name="logger"></param>
+    public CookieService(IHttpContextAccessor httpContextAccessor, ILogger<CookieService> logger)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the value of a cookie.
+    /// </summary>
+    /// <param name="cookieName"></param>
+    /// <returns>The value of the cookie or <see langword="null"/> if not found.</returns>
+    public string? GetCookieValue(string cookieName)
+    {
+        if (!EnsureHttpContext())
+        {
+            return null;
+        }
+
+        _httpContextAccessor.HttpContext!.Request.Cookies.TryGetValue(cookieName, out var cookieValue);
+        return cookieValue;
+    }
+
+    /// <summary>
+    /// Sets the value of a cookie.
+    /// </summary>
+    /// <param name="cookieName"></param>
+    /// <param name="cookieValue"></param>
+    /// <param name="expireTime"></param>
+    /// <returns><see langword="true"/> if the cookie could be set.</returns>
+    public bool SetCookieValue(string cookieName, string cookieValue, TimeSpan? expireTime = null)
+    {
+        if (!EnsureHttpContext())
+        {
+            return false;
+        }
+
+        _httpContextAccessor.HttpContext!.Response.Cookies.Append(cookieName, cookieValue, new CookieOptions
+        {
+            Expires = expireTime.HasValue ? DateTime.Now.Add(expireTime.Value) : DateTime.Now.AddYears(1),
+            HttpOnly = true, IsEssential = true, Secure = true, SameSite = SameSiteMode.Strict
+        });
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes a cookie.
+    /// </summary>
+    /// <param name="cookieName"></param>
+    public void RemoveCookie(string cookieName)
+    {
+        if (!EnsureHttpContext())
+        {
+            return;
+        }
+
+        _httpContextAccessor.HttpContext!.Response.Cookies.Delete(cookieName);
+    }
+
+    private bool EnsureHttpContext()
+    {
+        if (_httpContextAccessor.HttpContext == null)
+        {
+            _logger.LogCritical("HttpContext is null");
+            return false;
+        }
+        return true;
+    }
+}

--- a/Src/TournamentCalendar/Services/ICookieService.cs
+++ b/Src/TournamentCalendar/Services/ICookieService.cs
@@ -1,0 +1,8 @@
+﻿namespace TournamentCalendar.Services;
+
+public interface ICookieService
+{
+    string? GetCookieValue(string cookieName);
+    bool SetCookieValue(string cookieName, string cookieValue, TimeSpan? expireTime);
+    void RemoveCookie(string cookieName);
+}

--- a/Src/TournamentCalendar/Services/UserLocationService.cs
+++ b/Src/TournamentCalendar/Services/UserLocationService.cs
@@ -1,0 +1,140 @@
+﻿using TournamentCalendar.Data;
+using TournamentCalendarDAL.EntityClasses;
+
+namespace TournamentCalendar.Services;
+
+/// <summary>
+/// The user location.
+/// </summary>
+/// <param name="Latitude"></param>
+/// <param name="Longitude"></param>
+public record struct UserLocation(double? Latitude, double? Longitude)
+{
+    public bool IsSet => Latitude.HasValue && Longitude.HasValue;
+}
+
+/// <summary>
+/// The user location service is responsible for handling the user's location.
+/// </summary>
+public class UserLocationService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ICookieService _cookieService;
+    private readonly IAppDb _appDb;
+
+    public const string UserLocationSessionName = nameof(UserLocationSessionName);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserLocationService"/> class.
+    /// </summary>
+    /// <param name="httpContextAccessor"></param>
+    /// <param name="appDb"></param>
+    /// <param name="cookieService"></param>
+    public UserLocationService(IHttpContextAccessor httpContextAccessor, IAppDb appDb, ICookieService cookieService)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _appDb = appDb;
+        _cookieService = cookieService;
+    }
+
+    /// <summary>
+    /// Sets the user's location.
+    /// </summary>
+    /// <param name="latitude"></param>
+    /// <param name="longitude"></param>
+    public void SetGeoLocation(double latitude, double longitude)
+    {
+        SetGeoLocation(new UserLocation(latitude, longitude));
+    }
+
+    /// <summary>
+    /// Sets the user's location.
+    /// </summary>
+    /// <param name="userLocation"></param>
+    public void SetGeoLocation(UserLocation userLocation)
+    {
+        var loc = Location2String(userLocation);
+        _httpContextAccessor.HttpContext?.Session.SetString(UserLocationSessionName, loc);
+        _cookieService.SetCookieValue(CookieService.LocationCookieName, loc, null);
+    }
+
+    /// <summary>
+    /// Clears the user's location.
+    /// </summary>
+    public void ClearGeoLocation()
+    {
+        _httpContextAccessor.HttpContext?.Session.Remove(UserLocationSessionName);
+        _cookieService.RemoveCookie(CookieService.LocationCookieName);
+    }
+
+    /// <summary>
+    /// Sets the user's location from the user's GUID.
+    /// </summary>
+    /// <param name="userGuid"></param>
+    public void SetFromUserGuid(Guid userGuid)
+    {
+        var infoService = new InfoServiceEntity();
+        if (_appDb.InfoServiceRepository.GetRegistrationByGuid(infoService, userGuid.ToString("N")))
+        {
+            if (infoService is { ConfirmedOn: not null, UnSubscribedOn: null, Latitude: not null, Longitude: not null })
+            {
+                SetGeoLocation(infoService.Latitude.Value, infoService.Longitude.Value);
+                return;
+            }
+        }
+
+        ClearGeoLocation();
+    }
+
+    /// <summary>
+    /// Gets the user's location from the session or the cookie.
+    /// </summary>
+    /// <returns></returns>
+    public UserLocation GetLocation()
+    {
+        var userLocation = GetLocationFromSession();
+        if (userLocation.IsSet)
+        {
+            return userLocation;
+        }
+
+        if (_cookieService.GetCookieValue(CookieService.LocationCookieName) is { } cookieLocation
+            && TryString2Location(cookieLocation, out userLocation))
+        {
+            SetGeoLocation(userLocation);
+            return userLocation;
+        }
+
+        return new UserLocation(null, null);
+    }
+
+    private UserLocation GetLocationFromSession()
+    {
+        if (_httpContextAccessor.HttpContext?.Session.GetString(UserLocationSessionName) is { } sessionLocation
+            && TryString2Location(sessionLocation, out var userLocation))
+        {
+            return userLocation;
+        }
+
+        return new UserLocation(null, null);
+    }
+
+    private bool TryString2Location(string location, out UserLocation userLocation)
+    {
+        var parts = location.Split('|');
+        if (parts.Length == 2 && double.TryParse(parts[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var latitude) && double.TryParse(parts[1], NumberStyles.Any, CultureInfo.InvariantCulture, out var longitude))
+        {
+            userLocation = new UserLocation(latitude, longitude);
+            return true;
+        }
+
+        userLocation = new UserLocation(null, null);
+        return false;
+    }
+
+    private string Location2String(UserLocation userLocation)
+    {
+        return
+            $"{userLocation.Latitude?.ToString("###.########", CultureInfo.InvariantCulture)}|{userLocation.Longitude?.ToString("###.########", CultureInfo.InvariantCulture)}";
+    }
+}

--- a/Src/TournamentCalendar/Services/UserLocationService.cs
+++ b/Src/TournamentCalendar/Services/UserLocationService.cs
@@ -25,6 +25,7 @@ public class UserLocationService
     private readonly ICookieService _cookieService;
     private readonly IAppDb _appDb;
 
+    private const string LatLonFormat = "###.########";
     public const string UserLocationSessionName = nameof(UserLocationSessionName);
 
     /// <summary>
@@ -84,13 +85,11 @@ public class UserLocationService
     public void SetFromUserGuid(Guid userGuid)
     {
         var infoService = new InfoServiceEntity();
-        if (_appDb.InfoServiceRepository.GetRegistrationByGuid(infoService, userGuid.ToString("N")))
+        if (_appDb.InfoServiceRepository.GetRegistrationByGuid(infoService, userGuid.ToString("N"))
+            && infoService is { ConfirmedOn: not null, UnSubscribedOn: null, Latitude: not null, Longitude: not null })
         {
-            if (infoService is { ConfirmedOn: not null, UnSubscribedOn: null, Latitude: not null, Longitude: not null })
-            {
-                SetGeoLocation(infoService.Latitude.Value, infoService.Longitude.Value);
-                return;
-            }
+            SetGeoLocation(infoService.Latitude.Value, infoService.Longitude.Value);
+            return;
         }
 
         ClearGeoLocation();
@@ -145,10 +144,10 @@ public class UserLocationService
         return false;
     }
 
-    private string Location2String(UserLocation userLocation)
+    private static string Location2String(UserLocation userLocation)
     {
         return userLocation.IsSet
-            ? $"{userLocation.Latitude?.ToString("###.########", CultureInfo.InvariantCulture)}|{userLocation.Longitude?.ToString("###.########", CultureInfo.InvariantCulture)}"
+            ? $"{userLocation.Latitude?.ToString(LatLonFormat, CultureInfo.InvariantCulture)}|{userLocation.Longitude?.ToString(LatLonFormat, CultureInfo.InvariantCulture)}"
             : string.Empty;
     }
 

--- a/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -3,7 +3,7 @@
 @using TournamentCalendar.Views
 <div class="row">
     <div class="col-md-6">
-        <h3 class="h3">Turnierkalender</h3>
+        <h3 class="h3">@ViewBag.TitleTagText</h3>
         <p>
             Auf dieser Seite erscheinen primär Volleyball-Turniere aus dem deutschsprachigen Raum.
         </p>
@@ -19,6 +19,7 @@
         @* Hide on devices smaller than MD *@
         <img src="@Url.Content("~/images/ball-crown.jpg")" class="rounded text-right" alt="Turniere" style="width: 100%" />
     </div>
+    
     <div class="col-md-12">
     @if (Model.DisplayModel.Any())
     {
@@ -30,7 +31,7 @@
     </div>
     <div class="pb-2 table-responsive">
         <table id="tournaments-table" class="table table-striped table-bordered border-light table-hover rounded">
-        <thead>
+            <thead>
             <tr>
                 <th>Datum</th>
                 <th>Turniername</th>
@@ -38,12 +39,15 @@
                 <th>Art</th>
                 <th>Belag</th>
                 <th>PLZ</th>
+                <th>km</th>
                 <th class="text-center"><i class="bi bi-info-circle-fill"></i></th>
             </tr>
-        </thead>
-        <tbody>
+            </thead>
+            <tbody>
             @foreach (var m in Model.DisplayModel)
             {
+                var distance = m.GetDistanceToVenue();
+                var distanceStyle = distance < 150 ? "font-weight:bold" : "";
                 <tr id="@m.Id" title="Details zu &quot;@m.TournamentName&quot; - @m.Organizer">
                     <td>@m.DateFrom.ToString("dd.MM.yy")</td>
                     <td>@m.GetTournamentNameShort(60)</td>
@@ -51,12 +55,13 @@
                     <td>@m.GetTournamentTypeShort()</td>
                     <td>@m.GetSurface()</td>
                     <td>@m.CountryId-@m.PostalCode</td>
+                    <td style="@(distanceStyle)">@distance</td>
                     <td class="text-center"><a href="@Url.Action(nameof(Calendar.Id), nameof(Calendar), new {id = m.Id})" style="text-decoration: none" aria-label="@(m.TournamentName)"><i class="bi bi-info-circle @((DateTime.Now.Date - m.ModifiedOn.Date).Days < 2 ? "text-primary" : "")"></i></a></td>
                 </tr>
             }
-        </tbody>
-    </table>
-    <div class="small text-primary">Insgesamt @Model.DisplayModel.Count() Turniere im Kalender</div>
+            </tbody>
+        </table>
+        <div class="small text-primary">Insgesamt @Model.DisplayModel.Count() Turniere im Kalender</div>
     </div>
 </div>
 @section MetaSection {
@@ -96,12 +101,15 @@
     </style>
 }
 @section ScriptStandardSection {
-<script src="@Url.Content(ScriptName.Lib.SimpleDataTablesJs)" asp-append-version="true"></script>
-<script>
-//<![CDATA[
+    <script src="@Url.Content(ScriptName.Lib.SimpleDataTablesJs)" asp-append-version="true"></script>
+    <script>
+    //<![CDATA[
     'use strict';
+    
     document.addEventListener('DOMContentLoaded', OnDOMContentLoaded, false);
+
     function OnDOMContentLoaded() {
+
         const tournamentsTableElement = document.querySelector("#tournaments-table");
         const labelsEN = {
             placeholder: "Search...",
@@ -132,6 +140,11 @@
                 },
                 {
                     select: 5,
+                    searchable: false,
+                    type: 'number'
+                },
+                {
+                    select: 6,
                     sortable: false
                 }
             ],
@@ -145,7 +158,17 @@
         tournamentsTable.columns.sort(0, 'asc');
         makeRowsClickable();
         tournamentsTable.on('datatable.update', makeRowsClickable);
-        calcDistance();
+        @{
+            if (Model.IsGeoSpacial())
+            {
+                <text>tournamentsTable.columns.show(5);</text>
+            }
+            else
+            {
+                <text>tournamentsTable.columns.hide(5);</text>
+            }
+        }
+        //calcDistance();
         
         function makeRowsClickable()
         {
@@ -179,18 +202,11 @@
                         element.innerText = idDist.distance;
                     }
                 }
-                
-
-                
         }
     }
 
-    
-
-
-
     function haversineDistance(lat1, lon1, lat2, lon2, unit = 'K') {
-        const radius = 6371; // Earth's radius in kilometers
+        const radius = 6366.710; // Earth's radius in kilometers
         const dLat = (lat2 - lat1) * (Math.PI / 180);
         const dLon = (lon2 - lon1) * (Math.PI / 180);
         const a =
@@ -209,10 +225,6 @@
         }
         return distance; // Kilometers by default
     }
-
-    // const distanceKm = haversineDistance(40.774102, -73.971734, 40.771209, -73.9673991);
-    // console.log(`Distance: ${distanceKm} km`);
-
 //]]>
 </script>
 }

--- a/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -26,9 +26,9 @@
             @if (Model.DisplayModel.Any())
             {
                 var rec = Model.DisplayModel.Last();
-                <label class="m-0">
+                <span class="m-0 text-success">
                     <strong>Filtern der Tabelle</strong> (z.B.: &quot;@string.Join(string.Empty, rec.GetTournamentType().Take(5)).ToLower()&quot; für @rec.GetTournamentType()-Turniere)
-                </label>
+                </span>
             }
         </div>
         <div class="col-4 text-end p-0 text-nowrap">

--- a/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -112,6 +112,10 @@
         .datatable-table > thead > tr > th {
             padding: 8px 5px !important;
         }
+
+        input[type=search]::-webkit-search-cancel-button {
+            -webkit-appearance: searchfield-cancel-button;
+        }
     </style>
 }
 @section ScriptStandardSection {
@@ -196,6 +200,12 @@
                     window.location = link.href;
                 });
             });
+            
+            // Adjust 'datatable-search' container and input
+            const searchElement = document.querySelector('.datatable-search');
+            searchElement.classList.add('col-10', 'col-md-6');
+            const inputElement = searchElement.querySelector('input');
+            inputElement.type = 'search';
         }
     }
 //]]>

--- a/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -44,7 +44,7 @@
         <tbody>
             @foreach (var m in Model.DisplayModel)
             {
-                <tr title="Details zu &quot;@m.TournamentName&quot; - @m.Organizer">
+                <tr id="@m.Id" title="Details zu &quot;@m.TournamentName&quot; - @m.Organizer">
                     <td>@m.DateFrom.ToString("dd.MM.yy")</td>
                     <td>@m.GetTournamentNameShort(60)</td>
                     @*<td>@m.GetOrganizerShort(20)</td>*@
@@ -145,6 +145,7 @@
         tournamentsTable.columns.sort(0, 'asc');
         makeRowsClickable();
         tournamentsTable.on('datatable.update', makeRowsClickable);
+        calcDistance();
         
         function makeRowsClickable()
         {
@@ -159,7 +160,59 @@
                 });
             });
         }
+
+        function calcDistance() {
+                const locList = @Html.Raw(Json.Serialize(Model.DisplayModel.Select(m => new { m.Id, lat = m.Latitude, lon = m.Longitude })));
+
+                // Augsburg
+                const lat1 = 48.37153888888889;
+                const lon1 = 10.898511111111112;
+
+                const idDistList = locList.map(loc => {
+                    const d = haversineDistance(lat1, lon1, loc.lat, loc.lon);
+                    return { id: loc.id, distance: Math.round(d) };
+                });
+
+                for (const idDist of idDistList) {
+                    const element = document.getElementById(idDist.id).lastElementChild;
+                    if (element) {
+                        element.innerText = idDist.distance;
+                    }
+                }
+                
+
+                
+        }
     }
+
+    
+
+
+
+    function haversineDistance(lat1, lon1, lat2, lon2, unit = 'K') {
+        const radius = 6371; // Earth's radius in kilometers
+        const dLat = (lat2 - lat1) * (Math.PI / 180);
+        const dLon = (lon2 - lon1) * (Math.PI / 180);
+        const a =
+            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos((lat1 * Math.PI) / 180) *
+                Math.cos((lat2 * Math.PI) / 180) *
+                Math.sin(dLon / 2) *
+                Math.sin(dLon / 2);
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        const distance = radius * c;
+
+        if (unit === 'M') {
+            return distance * 0.621371; // Convert to miles
+        } else if (unit === 'N') {
+            return distance * 0.539957; // Convert to nautical miles
+        }
+        return distance; // Kilometers by default
+    }
+
+    // const distanceKm = haversineDistance(40.774102, -73.971734, 40.771209, -73.9673991);
+    // console.log(`Distance: ${distanceKm} km`);
+
 //]]>
 </script>
 }

--- a/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -1,5 +1,7 @@
-﻿@model TournamentCalendar.Models.Calendar.BrowseModel
+﻿@inject UserLocationService userLocation
+@model TournamentCalendar.Models.Calendar.BrowseModel
 @using TournamentCalendar.Controllers
+@using TournamentCalendar.Services
 @using TournamentCalendar.Views
 <div class="row">
     <div class="col-md-6">
@@ -19,15 +21,27 @@
         @* Hide on devices smaller than MD *@
         <img src="@Url.Content("~/images/ball-crown.jpg")" class="rounded text-right" alt="Turniere" style="width: 100%" />
     </div>
-    
-    <div class="col-md-12">
-    @if (Model.DisplayModel.Any())
-    {
-        var rec = Model.DisplayModel.Last();
-        <label style="margin: 0 10px 10px 0; font-size: 1rem; display: inline-block">
-                <strong>Filtern der Tabelle</strong><br />(z.B.: &quot;<b>.@rec.DateFrom.ToString("MM.yy")</b>&quot; für &quot;alle Turniere im @rec.DateFrom.ToString("MMMM")&quot; oder &quot;<b>@string.Join(string.Empty, rec.GetTournamentType().Take(5)).ToLower()</b>&quot; für @rec.GetTournamentType()-Turniere)
-        </label>
-    }
+    <div class="row justify-content-between pe-0">
+        <div class="col-8 pt-0 pe-0 fs-6">
+            @if (Model.DisplayModel.Any())
+            {
+                var rec = Model.DisplayModel.Last();
+                <label class="m-0">
+                    <strong>Filtern der Tabelle</strong> (z.B.: &quot;@string.Join(string.Empty, rec.GetTournamentType().Take(5)).ToLower()&quot; für @rec.GetTournamentType()-Turniere)
+                </label>
+            }
+        </div>
+        <div class="col-4 text-end p-0 text-nowrap">
+            @if (!userLocation.GetLocation().IsSet)
+            {
+                <span class="d-inline-block d-md-none fs-6">
+                    <a asp-action="@nameof(GeoLocation.Index)" asp-controller="@nameof(GeoLocation)"><b><span class="bi bi-square text-danger"> Entfernungen</span></b></a>
+                </span>
+                <span class="d-none d-md-inline-block fs-5">
+                    <a asp-action="@nameof(GeoLocation.Index)" asp-controller="@nameof(GeoLocation)"><b><span class="bi bi-square text-danger"> Entfernungen anzeigen</span></b></a>
+                </span>
+            }
+        </div>
     </div>
     <div class="pb-2 table-responsive">
         <table id="tournaments-table" class="table table-striped table-bordered border-light table-hover rounded">
@@ -56,7 +70,7 @@
                     <td>@m.GetSurface()</td>
                     <td>@m.CountryId-@m.PostalCode</td>
                     <td style="@(distanceStyle)">@distance</td>
-                    <td class="text-center"><a href="@Url.Action(nameof(Calendar.Id), nameof(Calendar), new {id = m.Id})" style="text-decoration: none" aria-label="@(m.TournamentName)"><i class="bi bi-info-circle @((DateTime.Now.Date - m.ModifiedOn.Date).Days < 2 ? "text-primary" : "")"></i></a></td>
+                    <td class="text-center"><a href="@Url.Action(nameof(Calendar.Id), nameof(Calendar), new { id = m.Id })" style="text-decoration: none" aria-label="@(m.TournamentName)"><i class="bi bi-info-circle @((DateTime.Now.Date - m.ModifiedOn.Date).Days < 2 ? "text-primary" : "")"></i></a></td>
                 </tr>
             }
             </tbody>
@@ -120,7 +134,7 @@
             noResults: "No results match your search query"
         };
         const labelsDE = {
-            placeholder: "Tabelle filtern...",
+            placeholder: "Suchen...",
             searchTitle: "Begriff(e) zum Filtern der Tabelle",
             perPage: "Einträge pro Seite",
             noRows: "Keine Einträge gefunden",
@@ -130,6 +144,7 @@
         const options = {
             searchable: true,
             sortable: true,
+            searchQuerySeparator: ' ',
             paging: false,
             fixedColumns: true,
             columns: [
@@ -168,7 +183,6 @@
                 <text>tournamentsTable.columns.hide(5);</text>
             }
         }
-        //calcDistance();
         
         function makeRowsClickable()
         {
@@ -183,47 +197,6 @@
                 });
             });
         }
-
-        function calcDistance() {
-                const locList = @Html.Raw(Json.Serialize(Model.DisplayModel.Select(m => new { m.Id, lat = m.Latitude, lon = m.Longitude })));
-
-                // Augsburg
-                const lat1 = 48.37153888888889;
-                const lon1 = 10.898511111111112;
-
-                const idDistList = locList.map(loc => {
-                    const d = haversineDistance(lat1, lon1, loc.lat, loc.lon);
-                    return { id: loc.id, distance: Math.round(d) };
-                });
-
-                for (const idDist of idDistList) {
-                    const element = document.getElementById(idDist.id).lastElementChild;
-                    if (element) {
-                        element.innerText = idDist.distance;
-                    }
-                }
-        }
-    }
-
-    function haversineDistance(lat1, lon1, lat2, lon2, unit = 'K') {
-        const radius = 6366.710; // Earth's radius in kilometers
-        const dLat = (lat2 - lat1) * (Math.PI / 180);
-        const dLon = (lon2 - lon1) * (Math.PI / 180);
-        const a =
-            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-                Math.cos((lat1 * Math.PI) / 180) *
-                Math.cos((lat2 * Math.PI) / 180) *
-                Math.sin(dLon / 2) *
-                Math.sin(dLon / 2);
-        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        const distance = radius * c;
-
-        if (unit === 'M') {
-            return distance * 0.621371; // Convert to miles
-        } else if (unit === 'N') {
-            return distance * 0.539957; // Convert to nautical miles
-        }
-        return distance; // Kilometers by default
     }
 //]]>
 </script>

--- a/Src/TournamentCalendar/Views/Calendar/_ShowSingleEntry.cshtml
+++ b/Src/TournamentCalendar/Views/Calendar/_ShowSingleEntry.cshtml
@@ -84,10 +84,10 @@
             </th>
             <td>
                 @Model.GetVenueAddress()
-                @if (Model.Longitude.HasValue && Model.Latitude.HasValue)
+                @if (Model.IsGeoSpatial())
                 {
                     <div>
-                        <a href="#" class="link" title="zur Karte scrollen" onclick="document.getElementById('mapPlaceholder').scrollIntoView();return false;">zur Karte scrollen</a>
+                        <span>Luftlinie: @Model.GetDistanceToVenue() km</span> <a href="#" class="link" title="zur Karte scrollen" onclick="document.getElementById('mapPlaceholder').scrollIntoView();return false;">zur Karte scrollen</a>
                     </div>
                 }
             </td>
@@ -121,7 +121,7 @@
                 Kontaktadresse:
             </th>
             <td>
-                @Html.Raw(Model.GetContactAddr())
+                @Html.Raw(Model.GetContactAddress())
             </td>
         </tr>
         <tr>
@@ -141,15 +141,15 @@
             </td>
         </tr>
     </table>
-@if (Model.Longitude.HasValue && Model.Latitude.HasValue)
+@if (Model is { Longitude: not null, Latitude: not null })
 {
     <div class="rounded pb-3 col-12 shadow">
         <div class="py-2">
-            <a href="@Model.GetVenueGoogleMapsLink()" class="link" title="Karte auf Google Maps Website anzeigen" target="_blank">Karte auf Google Maps Website anzeigen</a>
+            <a href="@Model.GetVenueGoogleMapsLink()" class="link" title="Route auf Google Maps Website anzeigen" target="_blank">Karte auf Google Maps Website anzeigen</a>
         </div>
         <div id="mapPlaceholder" class="rounded" style="border: 1px solid #979797; background-color: #e5e3df; width: 100%; height: 400px">
             <div style="padding: 1rem; color: gray">
-                Karte wird angezeigt,<br/>wenn der Standort gefunden wurde.
+                Karte wird angezeigt, <br/>wenn der Standort gefunden wurde.
             </div>
         </div>
     </div>

--- a/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
+++ b/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
@@ -24,8 +24,9 @@
             if (userLocation.IsSet)
             {
                 <div>
-                    <span class="text-success"><b>Eigener Standort ist festgelegt.</b></span> 
-                    <a href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link text-nowrap" target="_blank">auf Google Maps anzeigen
+                    <span class="text-success"><b>Eigener Standort ist festgelegt.</b></span>
+                    <a rel="noopener" href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link text-nowrap" target="_blank">
+                        auf Google Maps anzeigen
                         <img alt="Festgelegter Standort" class="img-fluid rounded d-block" src="https://maps.googleapis.com/maps/api/staticmap?center=@(userLocation.Latitude.Value.ToString("###.#######", CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString("###.#######", CultureInfo.InvariantCulture))&zoom=10&size=600x300&maptype=roadmap&key=@(googleConfig.WebApiKey)&markers=color:red%7C@(userLocation.Latitude.Value.ToString("###.#######", CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString("###.#######", CultureInfo.InvariantCulture))"/>
                     </a>
                 </div>

--- a/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
+++ b/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
@@ -1,0 +1,148 @@
+﻿@inject UserLocationService LocationService
+@using TournamentCalendar.Controllers
+@using TournamentCalendar.Services
+@using System.Globalization
+@{
+    var userLocation = LocationService.GetLocation();
+}
+<div class="row">
+    <div class="col-12 mb-3">
+        <h3 class="h3">@ViewBag.TitleTagText</h3>
+        <p>
+            Es ist möglich, im Turnierkalender die Entfernungen
+            vom eigenen Standort zu den Turnierstandorten anzuzeigen.
+        </p>
+        <div id="geo-supported" style="display:none">
+            <p>
+                Zuverlässige Standorte erfordern ein Gerät mit eingeschaltetem GPS-Empfänger oder
+                näherungsweise eine Internetverbindung über WLAN.
+            </p>
+            <p>
+                Dafür benötigt der Browser einmalig die Genehmigung, den Standort des Geräts abzufragen.
+            </p>
+            @{
+                if (userLocation.IsSet)
+                {
+                    <p>
+                        Derzeit verwendeten eigenen Standort <a href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link" target="_blank">auf Google Maps ansehen</a>.
+                    </p>
+                }
+                else
+                {
+                    <p>
+                        Derzeit ist der eigene Standort nicht festgelegt.
+                    </p>  
+                }
+            }
+            <div>
+                <button id="clear-location" type="button" class="btn btn-secondary">Standort entfernen</button>
+                <button id="set-location" type="button" class="btn btn-primary">Standort abrufen</button>
+            </div>
+            <div id="error-msg" class="alert alert-danger mt-3 mb-3" style="display:none"></div>
+        </div>
+        <div id="geo-not-supported" style="display:none">
+            <p>
+                Schade, leider unterstützt der Browser diese Funktionalität nicht.
+            </p>
+        </div>
+    </div>
+</div>
+@section ScriptStandardSection {
+<script>
+    //<![CDATA[
+    'use strict';
+    
+    document.addEventListener('DOMContentLoaded', OnDOMContentLoaded, false);
+
+    function OnDOMContentLoaded() {
+        if (navigator.geolocation) {
+            document.getElementById('geo-supported').style.display = 'block';
+        } else {
+            document.getElementById('geo-not-supported').style.display = 'block';
+        }
+
+        document.getElementById('set-location').addEventListener('click', function() {
+            try {
+                clearErrorMessage();
+                getGeoLocation();
+            } catch (e) {
+                setErrorMessage('Fehler beim Abruf der Standortposition');
+            }
+        });
+
+        document.getElementById('clear-location').addEventListener('click', function() {
+            try {
+                clearErrorMessage();
+                clearGeoLocation();
+            } catch (e) {
+                setErrorMessage('Fehler beim Entfernen der Standortposition');
+            } 
+        });
+    }
+
+    function getGeoLocation() {
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(submitLocation, handleError);
+        }
+    }
+
+    function submitLocation(position) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', window.location.origin + `/geolocation/location/${position.coords.latitude}/${position.coords.longitude}`, true);
+        xhr.onreadystatechange = function() {
+            // Request is complete and successful *OR* headers received and no content
+            if ((xhr.readyState === 4 && xhr.status === 200) || (xhr.readyState === 2 && xhr.status === 204)) {
+                window.location.reload();
+            } else {
+                setErrorMessage('Standort konnte nicht gesetzt werden - offline?');
+            }
+
+        };
+        xhr.send();
+    }
+
+    function handleError(error) {
+        switch (error.code) {
+        case error.PERMISSION_DENIED:
+            setErrorMessage('Keine Erlaubnis zum Abruf des Standorts');
+            break;
+        case error.POSITION_UNAVAILABLE:
+            setErrorMessage('Standortposition steht nicht zur Verfügung');
+            break;
+        case error.TIMEOUT:
+            setErrorMessage('Abruf der Standortposition dauert zu lange');
+            break;
+        case error.UNKNOWN_ERROR:
+            setErrorMessage('Fehler beim Abruf der Standortposition');
+            break;
+        }
+    }
+
+    function clearGeoLocation() {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', window.location.origin + `/geolocation/clear`, true);
+        xhr.onreadystatechange = function() {
+            // Request is complete and successful OR headers received and no content
+            if ((xhr.readyState === 4 && xhr.status === 200) || (xhr.readyState === 2 && xhr.status === 204))  {
+                window.location.reload();
+            } else {
+                setErrorMessage('Standort konnte nicht entfernt werden - offline?');
+            }
+        };
+        xhr.send();
+    }
+
+    function setErrorMessage(message) {
+        const errorMessage = document.getElementById('error-msg');
+        errorMessage.innerHTML = message;
+        errorMessage.style.display = 'block';
+    }
+
+    function clearErrorMessage() {
+        const errorMessage = document.getElementById('error-msg');
+        errorMessage.innerHTML = '';
+        errorMessage.style.display = 'none';
+    }
+//]]>
+</script>
+}

--- a/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
+++ b/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
@@ -24,13 +24,13 @@
                 if (userLocation.IsSet)
                 {
                     <p>
-                        Derzeit verwendeten eigenen Standort <a href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link" target="_blank">auf Google Maps ansehen</a>.
+                        <span class="text-success"><b>Eigener Standort ist bereits festgelegt.</b></span> <a href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link" target="_blank">auf Google Maps ansehen</a>.
                     </p>
                 }
                 else
                 {
-                    <p>
-                        Derzeit ist der eigene Standort nicht festgelegt.
+                    <p class="text-danger">
+                        <b>Derzeit ist der eigene Standort nicht festgelegt.</b>
                     </p>  
                 }
             }

--- a/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
+++ b/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
@@ -9,6 +9,7 @@
 @using TournamentCalendar.Library
 @using TournamentCalendarDAL.HelperClasses
 @{
+    const string LatLonFormat = "###.######";
     var userLocation = LocationService.GetLocation();
     var googleConfig = new GoogleConfiguration();
     Configuration.Bind(nameof(GoogleConfiguration), googleConfig);
@@ -27,7 +28,7 @@
                     <span class="text-success"><b>Eigener Standort ist festgelegt.</b></span>
                     <a rel="noopener" href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link text-nowrap" target="_blank">
                         auf Google Maps anzeigen
-                        <img alt="Festgelegter Standort" class="img-fluid rounded d-block" src="https://maps.googleapis.com/maps/api/staticmap?center=@(userLocation.Latitude.Value.ToString("###.#######", CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString("###.#######", CultureInfo.InvariantCulture))&zoom=10&size=600x300&maptype=roadmap&key=@(googleConfig.WebApiKey)&markers=color:red%7C@(userLocation.Latitude.Value.ToString("###.#######", CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString("###.#######", CultureInfo.InvariantCulture))"/>
+                        <img alt="Festgelegter Standort" class="img-fluid rounded d-block" src="https://maps.googleapis.com/maps/api/staticmap?center=@(userLocation.Latitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture))&zoom=10&size=600x300&maptype=roadmap&key=@(googleConfig.WebApiKey)&markers=color:red%7C@(userLocation.Latitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString(LatLonFormat, CultureInfo.InvariantCulture))"/>
                     </a>
                 </div>
                 <div class="mt-3 mb-3">

--- a/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
+++ b/Src/TournamentCalendar/Views/GeoLocation/Index.cshtml
@@ -1,52 +1,95 @@
 ﻿@inject UserLocationService LocationService
+@inject IConfiguration Configuration
+@model TournamentCalendar.Models.GeoLocation.EditModel
 @using TournamentCalendar.Controllers
 @using TournamentCalendar.Services
 @using System.Globalization
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.Extensions.Configuration
+@using TournamentCalendar.Library
+@using TournamentCalendarDAL.HelperClasses
 @{
     var userLocation = LocationService.GetLocation();
+    var googleConfig = new GoogleConfiguration();
+    Configuration.Bind(nameof(GoogleConfiguration), googleConfig);
 }
 <div class="row">
     <div class="col-12 mb-3">
         <h3 class="h3">@ViewBag.TitleTagText</h3>
         <p>
             Es ist möglich, im Turnierkalender die Entfernungen
-            vom eigenen Standort zu den Turnierstandorten anzuzeigen.
+            von einem festgelegten, eigenen Standort zu den Turnierstandorten anzuzeigen.
         </p>
-        <div id="geo-supported" style="display:none">
-            <p>
-                Zuverlässige Standorte erfordern ein Gerät mit eingeschaltetem GPS-Empfänger oder
-                näherungsweise eine Internetverbindung über WLAN.
-            </p>
-            <p>
-                Dafür benötigt der Browser einmalig die Genehmigung, den Standort des Geräts abzufragen.
-            </p>
-            @{
-                if (userLocation.IsSet)
-                {
-                    <p>
-                        <span class="text-success"><b>Eigener Standort ist bereits festgelegt.</b></span> <a href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link" target="_blank">auf Google Maps ansehen</a>.
-                    </p>
-                }
-                else
-                {
-                    <p class="text-danger">
-                        <b>Derzeit ist der eigene Standort nicht festgelegt.</b>
-                    </p>  
-                }
+        @{
+            if (userLocation.IsSet)
+            {
+                <div>
+                    <span class="text-success"><b>Eigener Standort ist festgelegt.</b></span> 
+                    <a href="@($"https://maps.google.de?q={userLocation.Latitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)},{userLocation.Longitude!.Value.ToString("###.########", CultureInfo.InvariantCulture)}")" class="link text-nowrap" target="_blank">auf Google Maps anzeigen
+                        <img alt="Festgelegter Standort" class="img-fluid rounded d-block" src="https://maps.googleapis.com/maps/api/staticmap?center=@(userLocation.Latitude.Value.ToString("###.#######", CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString("###.#######", CultureInfo.InvariantCulture))&zoom=10&size=600x300&maptype=roadmap&key=@(googleConfig.WebApiKey)&markers=color:red%7C@(userLocation.Latitude.Value.ToString("###.#######", CultureInfo.InvariantCulture)),@(userLocation.Longitude.Value.ToString("###.#######", CultureInfo.InvariantCulture))"/>
+                    </a>
+                </div>
+                <div class="mt-3 mb-3">
+                    <input type="button" value="Standort entfernen" class="cancel btn btn-secondary" onclick="location.href = '@Url.Action(nameof(GeoLocation.ClearLocation), nameof(GeoLocation))'"/>
+                </div>
             }
-            <div>
-                <button id="clear-location" type="button" class="btn btn-secondary">Standort entfernen</button>
-                <button id="set-location" type="button" class="btn btn-primary">Standort abrufen</button>
+            else
+            {
+                <div class="text-danger">
+                    <b>Der eigene Standort ist nicht festgelegt.</b>
+                </div>  
+            }
+        }
+        <fieldset class="rounded mt-3 mb-3">
+            <h4 class="h4">Position des Geräts verwenden</h4>
+            <div id="geo-supported" style="display:none">
+                <p>
+                    Zuverlässige Standorte erfordern ein Gerät mit eingeschaltetem GPS-Empfänger oder
+                    näherungsweise eine Internetverbindung über WLAN.
+                </p>
+                <p>
+                    Dafür benötigt der Browser einmalig die Genehmigung, den Standort des Geräts abzufragen.
+                </p>
+                <div>
+                    <button id="set-location" type="button" class="btn btn-primary">Standort abrufen</button>
+                </div>
+                <div id="error-msg" class="alert alert-danger mt-3 mb-3" style="display:none"></div>
             </div>
-            <div id="error-msg" class="alert alert-danger mt-3 mb-3" style="display:none"></div>
-        </div>
-        <div id="geo-not-supported" style="display:none">
+            <div id="geo-not-supported" style="display:none">
+                <p>
+                    Schade, leider unterstützt der Browser diese Funktionalität nicht.
+                </p>
+            </div>
+        </fieldset>
+        <fieldset class="rounded">
+            <h4 class="h4">Standort per Adresse festlegen</h4>
             <p>
-                Schade, leider unterstützt der Browser diese Funktionalität nicht.
+                Mehr Details führen zu genaueren Standortpositionen. Wird z.B. nur der Ort angegeben,
+                wird die geografische Ortsmitte verwendet. Das Land muss immer zutreffend angegeben sein.
             </p>
-        </div>
+            <form method="post" class="pb-2" novalidate>
+                <div id="AddressSection">
+                    <label asp-for="@Model.CountryId" class="form-label"></label>
+                    <select asp-for="@Model.CountryId" asp-items="(await Model.GetCountriesList())" class="form-select" style="width: 12rem"></select>
+                    <span asp-validation-for="@Model.CountryId" class="msg-error-text"></span>
+                    <label asp-for="@Model.ZipCode" class="form-label"></label>
+                    <input asp-for="@Model.ZipCode" maxlength="@InfoServiceFields.ZipCode.MaxLength" class="form-control" style="width:6rem">
+                    <span asp-validation-for="@Model.ZipCode" class="msg-error-text"></span>
+                    <label asp-for="@Model.City" class="form-label"></label>
+                    <input asp-for="@Model.City" maxlength="@InfoServiceFields.City.MaxLength" class="form-control">
+                    <span asp-validation-for="@Model.City" class="msg-error-text"></span>
+                    <label asp-for="@Model.Street" class="form-label"></label>
+                    <input asp-for="@Model.Street" maxlength="@InfoServiceFields.Street.MaxLength" class="form-control">
+                    <span asp-validation-for="@Model.Street" class="msg-error-text"></span>
+                </div>
+                <div class="mt-3">
+                    <input type="submit" name="save" formaction="@Url.Action(nameof(GeoLocation.Location), nameof(GeoLocation), new { model = Model })" value="Standort ermitteln" class="btn btn-primary" />
+                </div>
+            </form>
+        </fieldset>
     </div>
 </div>
+
 @section ScriptStandardSection {
 <script>
     //<![CDATA[
@@ -69,15 +112,6 @@
                 setErrorMessage('Fehler beim Abruf der Standortposition');
             }
         });
-
-        document.getElementById('clear-location').addEventListener('click', function() {
-            try {
-                clearErrorMessage();
-                clearGeoLocation();
-            } catch (e) {
-                setErrorMessage('Fehler beim Entfernen der Standortposition');
-            } 
-        });
     }
 
     function getGeoLocation() {
@@ -87,18 +121,19 @@
     }
 
     function submitLocation(position) {
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', window.location.origin + `/geolocation/location/${position.coords.latitude}/${position.coords.longitude}`, true);
-        xhr.onreadystatechange = function() {
-            // Request is complete and successful *OR* headers received and no content
-            if ((xhr.readyState === 4 && xhr.status === 200) || (xhr.readyState === 2 && xhr.status === 204)) {
-                window.location.reload();
-            } else {
+        fetch(window.location.origin + `/geolocation/location/${position.coords.latitude}/${position.coords.longitude}`, {
+                method: 'GET'
+            })
+            .then(response => {
+                if (response.ok || response.status === 204) {
+                    window.location.reload();
+                } else {
+                    setErrorMessage('Standort konnte nicht gesetzt werden - offline?');
+                }
+            })
+            .catch(error => {
                 setErrorMessage('Standort konnte nicht gesetzt werden - offline?');
-            }
-
-        };
-        xhr.send();
+            });
     }
 
     function handleError(error) {
@@ -116,20 +151,6 @@
             setErrorMessage('Fehler beim Abruf der Standortposition');
             break;
         }
-    }
-
-    function clearGeoLocation() {
-        const xhr = new XMLHttpRequest();
-        xhr.open('GET', window.location.origin + `/geolocation/clear`, true);
-        xhr.onreadystatechange = function() {
-            // Request is complete and successful OR headers received and no content
-            if ((xhr.readyState === 4 && xhr.status === 200) || (xhr.readyState === 2 && xhr.status === 204))  {
-                window.location.reload();
-            } else {
-                setErrorMessage('Standort konnte nicht entfernt werden - offline?');
-            }
-        };
-        xhr.send();
     }
 
     function setErrorMessage(message) {

--- a/Src/TournamentCalendar/Views/InfoService/Edit.cshtml
+++ b/Src/TournamentCalendar/Views/InfoService/Edit.cshtml
@@ -159,7 +159,6 @@
 </form>
 @section CssSection {}
 @section ScriptStandardSection {
-    @* Note: Google requires an API key for all requests since 11 June 2018 *@
     <script src="@string.Format("https://maps.googleapis.com/maps/api/js?callback=initMap&key={0}&language=de&region=DE", googleConfig.WebApiKey)" defer></script>
     <script src="@Url.Content(ScriptName.Js.Location)" asp-append-version="true"></script>
     <script>

--- a/Src/TournamentCalendar/Views/InfoService/Edit.cshtml
+++ b/Src/TournamentCalendar/Views/InfoService/Edit.cshtml
@@ -54,53 +54,43 @@
                 <label asp-for="@Model.Gender" class="form-label"></label>
                 <select asp-for="@Model.Gender" asp-items="Model.GetGenderList()" class="form-select input-required" style="width: 10rem"></select>
                 <span asp-validation-for="@Model.Gender" class="msg-error-text"></span>
-                <label asp-for="@Model.Title" class="form-label"></label>
-                <input asp-for="@Model.Title" maxlength="@InfoServiceFields.Title.MaxLength" class="form-control" >
-                <span asp-validation-for="@Model.Title" class="msg-error-text"></span>
                 <label asp-for="@Model.FirstName" class="form-label"></label>
                 <input asp-for="@Model.FirstName" maxlength="@InfoServiceFields.FirstName.MaxLength" class="form-control input-required" >
                 <span asp-validation-for="@Model.FirstName" class="msg-error-text"></span>
-                <label asp-for="@Model.Nickname" class="form-label"></label>
-                <input asp-for="@Model.Nickname" maxlength="@InfoServiceFields.Nickname.MaxLength" class="form-control" >
-                <span asp-validation-for="@Model.Nickname" class="msg-error-text"></span>
                 <label asp-for="@Model.LastName" class="form-label"></label>
                 <input asp-for="@Model.LastName" maxlength="@InfoServiceFields.LastName.MaxLength" class="form-control input-required" >
                 <span asp-validation-for="@Model.LastName" class="msg-error-text"></span>
-                <label asp-for="@Model.ClubName" class="form-label"></label>
-                <input asp-for="@Model.ClubName" maxlength="@InfoServiceFields.ClubName.MaxLength" class="form-control" >
-                <span asp-validation-for="@Model.ClubName" class="msg-error-text"></span>
-                <label asp-for="@Model.TeamName" class="form-label"></label>
-                <input asp-for="@Model.TeamName" maxlength="@InfoServiceFields.TeamName.MaxLength" class="form-control" >
-                <span asp-validation-for="@Model.TeamName" class="msg-error-text"></span>
             </div>
         </div>
     </fieldset>
     <fieldset class="rounded">
         <legend class="rounded">
-            Ich möchte nur Turnierinformationen rund um folgenden Standort
+            Angaben zur Entfernungsberechnung vom Standort zum Turnierort
         </legend>
         <div class="row">
             <div class="col">
+                <div>
+                    Für die Entfernungsberechnung kann eine beliebige Adresse verwendet werden.
+                    Ohne Straßenangabe wird die geografische Ortsmitte verwendet.
+                </div>
                 <div class="form-check">
-                    <input asp-for="@Model.IsAddressEntered" type="checkbox" class="form-check-input" />
+                    <input asp-for="@Model.IsAddressEntered" type="checkbox" class="form-check-input"/>
                     <label asp-for="@Model.IsAddressEntered" class="form-check-label"></label>
                 </div>
                 <span asp-validation-for="@Model.IsAddressEntered" class="msg-error-text"></span>
                 <div id="AddressSection" class="@(Model.IsAddressEntered ? "collapse show" : "collapse")">
-                    <label asp-for="@Model.MaxDistance" class="form-label">Maximale Entfernung in Kilometern von nachfolgendem Standort (ab 50 km)</label>
-                    <input asp-for="@Model.MaxDistance" type="text" maxlength="4" class="form-control" style="width: 5rem" >
-                    <span asp-validation-for="@Model.MaxDistance" class="msg-error-text"></span>
+
                     <label asp-for="@Model.CountryId" class="form-label"></label>
                     <select asp-for="@Model.CountryId" asp-items="(await Model.GetCountriesList())" class="form-select" style="width: 12rem"></select>
                     <span asp-validation-for="@Model.CountryId" class="msg-error-text"></span>
                     <label asp-for="@Model.ZipCode" class="form-label"></label>
-                    <input asp-for="@Model.ZipCode" maxlength="@InfoServiceFields.ZipCode.MaxLength" class="form-control" style="width:6rem" >
+                    <input asp-for="@Model.ZipCode" maxlength="@InfoServiceFields.ZipCode.MaxLength" class="form-control" style="width:6rem">
                     <span asp-validation-for="@Model.ZipCode" class="msg-error-text"></span>
                     <label asp-for="@Model.City" class="form-label"></label>
-                    <input asp-for="@Model.City" maxlength="@InfoServiceFields.City.MaxLength" class="form-control" >
+                    <input asp-for="@Model.City" maxlength="@InfoServiceFields.City.MaxLength" class="form-control">
                     <span asp-validation-for="@Model.City" class="msg-error-text"></span>
                     <label asp-for="@Model.Street" class="form-label"></label>
-                    <input asp-for="@Model.Street" maxlength="@InfoServiceFields.Street.MaxLength" class="form-control" >
+                    <input asp-for="@Model.Street" maxlength="@InfoServiceFields.Street.MaxLength" class="form-control">
                     <span asp-validation-for="@Model.Street" class="msg-error-text"></span>
                     <!-- Button trigger modal -->
                     <div class="pt-3">

--- a/Src/TournamentCalendar/Views/ViewName.cs
+++ b/Src/TournamentCalendar/Views/ViewName.cs
@@ -83,6 +83,18 @@ public static class ViewName
 
     #endregion
 
+    #region *** GeoLocation views ***
+
+    public static class GeoLocation
+    {
+        /// <summary>
+        /// ~/Views/GeoLocation/Index.cshtml
+        /// </summary>
+        public const string Index = "~/Views/GeoLocation/Index.cshtml";
+    }
+
+    #endregion
+
     #region *** Collect views ***
 
     /// <summary>

--- a/Src/TournamentCalendar/WebAppStartup.cs
+++ b/Src/TournamentCalendar/WebAppStartup.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SD.LLBLGen.Pro.ORMSupportClasses;
 using TournamentCalendar.Middleware;
+using TournamentCalendar.Services;
 
 namespace TournamentCalendar;
 
@@ -77,6 +78,9 @@ public static class WebAppStartup
             options.Cookie.IsEssential = true;
         });
 
+        services.AddHttpContextAccessor();
+        services.AddScoped<ICookieService, CookieService>();
+
         services.AddLocalization(options => options.ResourcesPath = "App_GlobalResources");
 
         services.AddRazorPages();
@@ -127,6 +131,7 @@ public static class WebAppStartup
         
         services.TryAddSingleton<Data.IDbContext>(dbContext);
         services.AddScoped<Data.IAppDb>(s => s.GetRequiredService<Data.IDbContext>().AppDb);
+        services.AddScoped<UserLocationService>();
 
         services.AddTransient<ClientAbortMiddleware>();
 

--- a/Src/TournamentCalender.Data/CountriesRepository.cs
+++ b/Src/TournamentCalender.Data/CountriesRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,7 +24,7 @@ public class CountriesRepository : GenericRepository
 
     public CountriesRepository(IDbContext dbContext) : base(dbContext) { }
 
-    public virtual async Task GetCountriesList(EntityCollection<CountryEntity> countries, string[] forIds, CancellationToken cancellationToken)
+    public virtual async Task GetCountriesList(EntityCollection<CountryEntity> countries, ICollection<string> forIds, CancellationToken cancellationToken)
     {
         using var da = _dbContext.GetNewAdapter();
         var metaData = new LinqMetaData(da);

--- a/Src/TournamentCalender.Data/InfoServiceRepository.cs
+++ b/Src/TournamentCalender.Data/InfoServiceRepository.cs
@@ -19,7 +19,19 @@ public class InfoServiceRepository : GenericRepository
 
     public virtual bool GetRegistrationByEmail(InfoServiceEntity entity, string email)
     {
-        return GetRegistration(entity, new PredicateExpression(InfoServiceFields.Email == email));
+        var predicate = new FieldCompareValuePredicate(
+            InfoServiceFields.Email,
+            null,
+            ComparisonOperator.Equal,
+            email
+        )
+        {
+            // If set to true, the UPPER() function is applied
+            CaseSensitiveCollation = true
+        };
+
+        var filter = new PredicateExpression(predicate);
+        return GetRegistration(entity, filter);
     }
 
     public virtual bool GetRegistration(InfoServiceEntity entity, PredicateExpression filter)


### PR DESCRIPTION
* Add "display distances" to the main menu (Navigation.config).
* Introduce `CookieService`, `UserLocationService`, and `UserLocation` classes to handle and store locations.
* Register `CookieService and UserLocationService in `WebStartup`.
* Create the `GeoLocation` class for setting the location from a GPS-enabled device and user input.
* Update the `InfoService` (aka "volley-news") controller for simplified subscription to the service.
* Refactored Axuno.Tools.GeoSpatial classes.
* Improve the tournament calendar view to show distances from the user to the tournament venue location.
* Fix an issue where a calendar entry could be flagged as deleted after editing.