### PR TITLE
Update npm packages

### DIFF
--- a/Src/TournamentCalendar/Styles/site/_std-input.scss
+++ b/Src/TournamentCalendar/Styles/site/_std-input.scss
@@ -2,6 +2,7 @@
 // Variables used locally
 // **************************************
 @import '../bootstrap/custom';
+$bootstrap-icons-font-dir: '../lib/bootstrap/fonts';
 @import '../../../TournamentCalendar/node_modules/bootstrap-icons/font/bootstrap-icons.scss';
 
 $label-color: $success;

--- a/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
+++ b/Src/TournamentCalendar/Views/Calendar/Overview.cshtml
@@ -112,10 +112,6 @@
         .datatable-table > thead > tr > th {
             padding: 8px 5px !important;
         }
-
-        input[type=search]::-webkit-search-cancel-button {
-            -webkit-appearance: searchfield-cancel-button;
-        }
     </style>
 }
 @section ScriptStandardSection {
@@ -146,8 +142,6 @@
             noResults: "Keine Einträge für die Suchbegriffe gefunden"
         };
         const options = {
-            searchable: true,
-            sortable: true,
             searchQuerySeparator: ' ',
             paging: false,
             fixedColumns: true,
@@ -155,16 +149,26 @@
                 {
                     select: 0,
                     type: 'date',
-                    format: 'DD.MM.YY'
+                    format: 'DD.MM.YY',
+                    searchable: true,
+                    sortable: true
                 },
                 {
+                    select: [1, 4],
+                    type: 'html',
+                    searchable: true,
+                    sortable: true
+                },
+                { 
                     select: 5,
+                    type: 'number',
                     searchable: false,
-                    type: 'number'
+                    sortable: true
                 },
                 {
                     select: 6,
-                    sortable: false
+                    sortable: false,
+                    searchable: true,
                 }
             ],
             labels: labelsDE,

--- a/Src/TournamentCalendar/package-lock.json
+++ b/Src/TournamentCalendar/package-lock.json
@@ -14,12 +14,12 @@
                 "@eonasdan/tempus-dominus": "6.9.6",
                 "@lodder/grunt-postcss": "3.1.1",
                 "@popperjs/core": "2.11.8",
-                "autoprefixer": "10.4.19",
+                "autoprefixer": "10.4.20",
                 "bootstrap": "5.3.3",
                 "bootstrap-icons": "1.11.3",
-                "cssnano": "7.0.3",
+                "cssnano": "7.0.5",
                 "grunt": "^1.6.1",
-                "grunt-cli": "1.4.3",
+                "grunt-cli": "1.5.0",
                 "grunt-contrib-concat": "2.1.0",
                 "grunt-contrib-copy": "1.0.0",
                 "grunt-contrib-cssmin": "5.0.0",
@@ -28,7 +28,7 @@
                 "grunt-sass": "3.1.0",
                 "jsnlog": "^2.30.0",
                 "node-sass": "9.0.0",
-                "simple-datatables": "9.0.3"
+                "simple-datatables": "9.1.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -380,9 +380,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.19",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-            "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+            "version": "10.4.20",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+            "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
             "dev": true,
             "funding": [
                 {
@@ -399,11 +399,11 @@
                 }
             ],
             "dependencies": {
-                "browserslist": "^4.23.0",
-                "caniuse-lite": "^1.0.30001599",
+                "browserslist": "^4.23.3",
+                "caniuse-lite": "^1.0.30001646",
                 "fraction.js": "^4.3.7",
                 "normalize-range": "^0.1.2",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "bin": {
@@ -498,9 +498,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+            "version": "4.23.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+            "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
             "dev": true,
             "funding": [
                 {
@@ -517,10 +517,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001629",
-                "electron-to-chromium": "^1.4.796",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.16"
+                "caniuse-lite": "^1.0.30001646",
+                "electron-to-chromium": "^1.5.4",
+                "node-releases": "^2.0.18",
+                "update-browserslist-db": "^1.1.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -663,9 +663,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001636",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
-            "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
+            "version": "1.0.30001653",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+            "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
             "dev": true,
             "funding": [
                 {
@@ -906,12 +906,12 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.3.tgz",
-            "integrity": "sha512-lsekJctOTqdCn4cNrtrSwsuMR/fHC+oiVMHkp/OugBWtwjH8XJag1/OtGaYJGtz0un1fQcRy4ryfYTQsfh+KSQ==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.5.tgz",
+            "integrity": "sha512-Aq0vqBLtpTT5Yxj+hLlLfNPFuRQCDIjx5JQAhhaedQKLNDvDGeVziF24PS+S1f0Z5KCxWvw0QVI3VNHNBITxVQ==",
             "dev": true,
             "dependencies": {
-                "cssnano-preset-default": "^7.0.3",
+                "cssnano-preset-default": "^7.0.5",
                 "lilconfig": "^3.1.2"
             },
             "engines": {
@@ -926,41 +926,41 @@
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.3.tgz",
-            "integrity": "sha512-dQ3Ba1p/oewICp/szF1XjFFgql8OlOBrI2YNBUUwhHQnJNoMOcQTa+Bi7jSJN8r/eM1egW0Ud1se/S7qlduWKA==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.5.tgz",
+            "integrity": "sha512-Jbzja0xaKwc5JzxPQoc+fotKpYtWEu4wQLMQe29CM0FjjdRjA4omvbGHl2DTGgARKxSTpPssBsok+ixv8uTBqw==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
+                "browserslist": "^4.23.3",
                 "css-declaration-sorter": "^7.2.0",
                 "cssnano-utils": "^5.0.0",
-                "postcss-calc": "^10.0.0",
-                "postcss-colormin": "^7.0.1",
-                "postcss-convert-values": "^7.0.1",
-                "postcss-discard-comments": "^7.0.1",
-                "postcss-discard-duplicates": "^7.0.0",
+                "postcss-calc": "^10.0.1",
+                "postcss-colormin": "^7.0.2",
+                "postcss-convert-values": "^7.0.3",
+                "postcss-discard-comments": "^7.0.2",
+                "postcss-discard-duplicates": "^7.0.1",
                 "postcss-discard-empty": "^7.0.0",
                 "postcss-discard-overridden": "^7.0.0",
-                "postcss-merge-longhand": "^7.0.2",
-                "postcss-merge-rules": "^7.0.2",
+                "postcss-merge-longhand": "^7.0.3",
+                "postcss-merge-rules": "^7.0.3",
                 "postcss-minify-font-values": "^7.0.0",
                 "postcss-minify-gradients": "^7.0.0",
-                "postcss-minify-params": "^7.0.1",
-                "postcss-minify-selectors": "^7.0.2",
+                "postcss-minify-params": "^7.0.2",
+                "postcss-minify-selectors": "^7.0.3",
                 "postcss-normalize-charset": "^7.0.0",
                 "postcss-normalize-display-values": "^7.0.0",
                 "postcss-normalize-positions": "^7.0.0",
                 "postcss-normalize-repeat-style": "^7.0.0",
                 "postcss-normalize-string": "^7.0.0",
                 "postcss-normalize-timing-functions": "^7.0.0",
-                "postcss-normalize-unicode": "^7.0.1",
+                "postcss-normalize-unicode": "^7.0.2",
                 "postcss-normalize-url": "^7.0.0",
                 "postcss-normalize-whitespace": "^7.0.0",
                 "postcss-ordered-values": "^7.0.1",
-                "postcss-reduce-initial": "^7.0.1",
+                "postcss-reduce-initial": "^7.0.2",
                 "postcss-reduce-transforms": "^7.0.0",
                 "postcss-svgo": "^7.0.1",
-                "postcss-unique-selectors": "^7.0.1"
+                "postcss-unique-selectors": "^7.0.2"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -1189,9 +1189,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.810",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.810.tgz",
-            "integrity": "sha512-Kaxhu4T7SJGpRQx99tq216gCq2nMxJo+uuT6uzz9l8TVN2stL7M06MIIXAtr9jsrLs2Glflgf2vMQRepxawOdQ==",
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+            "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -1700,16 +1700,16 @@
             }
         },
         "node_modules/grunt-cli": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.3.tgz",
-            "integrity": "sha512-9Dtx/AhVeB4LYzsViCjUQkd0Kw0McN2gYpdmGYKtE2a5Yt7v1Q+HYZVWhqXc/kGnxlMtqKDxSwotiGeFmkrCoQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.5.0.tgz",
+            "integrity": "sha512-rILKAFoU0dzlf22SUfDtq2R1fosChXXlJM5j7wI6uoW8gwmXDXzbUvirlKZSYCdXl3LXFbR+8xyS+WFo+b6vlA==",
             "dev": true,
             "dependencies": {
                 "grunt-known-options": "~2.0.0",
                 "interpret": "~1.1.0",
                 "liftup": "~3.0.1",
-                "nopt": "~4.0.1",
-                "v8flags": "~3.2.0"
+                "nopt": "~5.0.0",
+                "v8flags": "^4.0.1"
             },
             "bin": {
                 "grunt": "bin/grunt"
@@ -1719,16 +1719,18 @@
             }
         },
         "node_modules/grunt-cli/node_modules/nopt": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
             "dev": true,
             "dependencies": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/grunt-contrib-concat": {
@@ -1930,6 +1932,50 @@
             },
             "peerDependencies": {
                 "grunt": ">=1"
+            }
+        },
+        "node_modules/grunt/node_modules/grunt-cli": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.3.tgz",
+            "integrity": "sha512-9Dtx/AhVeB4LYzsViCjUQkd0Kw0McN2gYpdmGYKtE2a5Yt7v1Q+HYZVWhqXc/kGnxlMtqKDxSwotiGeFmkrCoQ==",
+            "dev": true,
+            "dependencies": {
+                "grunt-known-options": "~2.0.0",
+                "interpret": "~1.1.0",
+                "liftup": "~3.0.1",
+                "nopt": "~4.0.1",
+                "v8flags": "~3.2.0"
+            },
+            "bin": {
+                "grunt": "bin/grunt"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/grunt/node_modules/grunt-cli/node_modules/nopt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+            "dev": true,
+            "dependencies": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
+        "node_modules/grunt/node_modules/v8flags": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+            "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+            "dev": true,
+            "dependencies": {
+                "homedir-polyfill": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/gzip-size": {
@@ -3034,9 +3080,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
             "dev": true
         },
         "node_modules/node-sass": {
@@ -3434,12 +3480,12 @@
             }
         },
         "node_modules/postcss-calc": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.0.0.tgz",
-            "integrity": "sha512-OmjhudoNTP0QleZCwl1i6NeBwN+5MZbY5ersLZz69mjJiDVv/p57RjRuKDkHeDWr4T+S97wQfsqRTNoDHB2e3g==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.0.2.tgz",
+            "integrity": "sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==",
             "dev": true,
             "dependencies": {
-                "postcss-selector-parser": "^6.0.16",
+                "postcss-selector-parser": "^6.1.2",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -3450,12 +3496,12 @@
             }
         },
         "node_modules/postcss-colormin": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.1.tgz",
-            "integrity": "sha512-uszdT0dULt3FQs47G5UHCduYK+FnkLYlpu1HpWu061eGsKZ7setoG7kA+WC9NQLsOJf69D5TxGHgnAdRgylnFQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.2.tgz",
+            "integrity": "sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
+                "browserslist": "^4.23.3",
                 "caniuse-api": "^3.0.0",
                 "colord": "^2.9.3",
                 "postcss-value-parser": "^4.2.0"
@@ -3468,12 +3514,12 @@
             }
         },
         "node_modules/postcss-convert-values": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.1.tgz",
-            "integrity": "sha512-9x2ofb+hYPwHWMlWAzyWys2yMDZYGfkX9LodbaVTmLdlupmtH2AGvj8Up95wzzNPRDEzPIxQIkUaPJew3bT6xA==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.3.tgz",
+            "integrity": "sha512-yJhocjCs2SQer0uZ9lXTMOwDowbxvhwFVrZeS6NPEij/XXthl73ggUmfwVvJM+Vaj5gtCKJV1jiUu4IhAUkX/Q==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
+                "browserslist": "^4.23.3",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -3484,12 +3530,12 @@
             }
         },
         "node_modules/postcss-discard-comments": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.1.tgz",
-            "integrity": "sha512-GVrQxUOhmle1W6jX2SvNLt4kmN+JYhV7mzI6BMnkAWR9DtVvg8e67rrV0NfdWhn7x1zxvzdWkMBPdBDCls+uwQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.2.tgz",
+            "integrity": "sha512-/Hje9Ls1IYcB9duELO/AyDUJI6aQVY3h5Rj1ziXgaLYCTi1iVBLnjg/TS0D6NszR/kDG6I86OwLmAYe+bvJjiQ==",
             "dev": true,
             "dependencies": {
-                "postcss-selector-parser": "^6.1.0"
+                "postcss-selector-parser": "^6.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -3499,9 +3545,9 @@
             }
         },
         "node_modules/postcss-discard-duplicates": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.0.tgz",
-            "integrity": "sha512-bAnSuBop5LpAIUmmOSsuvtKAAKREB6BBIYStWUTGq8oG5q9fClDMMuY8i4UPI/cEcDx2TN+7PMnXYIId20UVDw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.1.tgz",
+            "integrity": "sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==",
             "dev": true,
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -3535,13 +3581,13 @@
             }
         },
         "node_modules/postcss-merge-longhand": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.2.tgz",
-            "integrity": "sha512-06vrW6ZWi9qeP7KMS9fsa9QW56+tIMW55KYqF7X3Ccn+NI2pIgPV6gFfvXTMQ05H90Y5DvnCDPZ2IuHa30PMUg==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.3.tgz",
+            "integrity": "sha512-8waYomFxshdv6M9Em3QRM9MettRLDRcH2JQi2l0Z1KlYD/vhal3gbkeSES0NuACXOlZBB0V/B0AseHZaklzWOA==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "stylehacks": "^7.0.2"
+                "stylehacks": "^7.0.3"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -3551,15 +3597,15 @@
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.2.tgz",
-            "integrity": "sha512-VAR47UNvRsdrTHLe7TV1CeEtF9SJYR5ukIB9U4GZyZOptgtsS20xSxy+k5wMrI3udST6O1XuIn7cjQkg7sDAAw==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.3.tgz",
+            "integrity": "sha512-2eSas2p3voPxNfdI5sQrvIkMaeUHpVc3EezgVs18hz/wRTQAC9U99tp9j3W5Jx9/L3qHkEDvizEx/LdnmumIvQ==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
+                "browserslist": "^4.23.3",
                 "caniuse-api": "^3.0.0",
                 "cssnano-utils": "^5.0.0",
-                "postcss-selector-parser": "^6.1.0"
+                "postcss-selector-parser": "^6.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -3601,12 +3647,12 @@
             }
         },
         "node_modules/postcss-minify-params": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.1.tgz",
-            "integrity": "sha512-e+Xt8xErSRPgSRFxHeBCSxMiO8B8xng7lh8E0A5ep1VfwYhY8FXhu4Q3APMjgx9YDDbSp53IBGENrzygbUvgUQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.2.tgz",
+            "integrity": "sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
+                "browserslist": "^4.23.3",
                 "cssnano-utils": "^5.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -3618,13 +3664,13 @@
             }
         },
         "node_modules/postcss-minify-selectors": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.2.tgz",
-            "integrity": "sha512-dCzm04wqW1uqLmDZ41XYNBJfjgps3ZugDpogAmJXoCb5oCiTzIX4oPXXKxDpTvWOnKxQKR4EbV4ZawJBLcdXXA==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.3.tgz",
+            "integrity": "sha512-SxTgUQSgBk6wEqzQZKEv1xQYIp9UBju6no9q+npohzSdhuSICQdkqmD1UMKkZWItS3olJSJMDDEY9WOJ5oGJew==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
-                "postcss-selector-parser": "^6.1.0"
+                "postcss-selector-parser": "^6.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -3721,12 +3767,12 @@
             }
         },
         "node_modules/postcss-normalize-unicode": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.1.tgz",
-            "integrity": "sha512-PTPGdY9xAkTw+8ZZ71DUePb7M/Vtgkbbq+EoI33EuyQEzbKemEQMhe5QSr0VP5UfZlreANDPxSfcdSprENcbsg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.2.tgz",
+            "integrity": "sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
+                "browserslist": "^4.23.3",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -3783,12 +3829,12 @@
             }
         },
         "node_modules/postcss-reduce-initial": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.1.tgz",
-            "integrity": "sha512-0JDUSV4bGB5FGM5g8MkS+rvqKukJZ7OTHw/lcKn7xPNqeaqJyQbUO8/dJpvyTpaVwPsd3Uc33+CfNzdVowp2WA==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.2.tgz",
+            "integrity": "sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
+                "browserslist": "^4.23.3",
                 "caniuse-api": "^3.0.0"
             },
             "engines": {
@@ -3814,9 +3860,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
-            "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -3843,12 +3889,12 @@
             }
         },
         "node_modules/postcss-unique-selectors": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.1.tgz",
-            "integrity": "sha512-MH7QE/eKUftTB5ta40xcHLl7hkZjgDFydpfTK+QWXeHxghVt3VoPqYL5/G+zYZPPIs+8GuqFXSTgxBSoB1RZtQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.2.tgz",
+            "integrity": "sha512-CjSam+7Vf8cflJQsHrMS0P2hmy9u0+n/P001kb5eAszLmhjMqrt/i5AqQuNFihhViwDvEAezqTmXqaYXL2ugMw==",
             "dev": true,
             "dependencies": {
-                "postcss-selector-parser": "^6.1.0"
+                "postcss-selector-parser": "^6.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4296,9 +4342,9 @@
             "dev": true
         },
         "node_modules/simple-datatables": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/simple-datatables/-/simple-datatables-9.0.3.tgz",
-            "integrity": "sha512-/QB3wSPLmz4IHfJIaTASiHJWIOmGEZVanKv9qwUOwGPEf+xILOdb30lm9i+jf/CPYpwbKf7Ti3yKIsF2ny+erQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/simple-datatables/-/simple-datatables-9.1.0.tgz",
+            "integrity": "sha512-0k5x8+71P1Hnn37VcdM/FpRxKLqBM+T32jqRgJiezbijUg6LbpepufkIDEpf8RtGmA6ftoz+FnAcn0Wj9yOQuA==",
             "dev": true,
             "dependencies": {
                 "dayjs": "^1.11.10",
@@ -4504,13 +4550,13 @@
             }
         },
         "node_modules/stylehacks": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.2.tgz",
-            "integrity": "sha512-HdkWZS9b4gbgYTdMg4gJLmm7biAUug1qTqXjS+u8X+/pUd+9Px1E+520GnOW3rST9MNsVOVpsJG+mPHNosxjOQ==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.3.tgz",
+            "integrity": "sha512-4DqtecvI/Nd+2BCvW9YEF6lhBN5UM50IJ1R3rnEAhBwbCKf4VehRf+uqvnVArnBayjYD/WtT3g0G/HSRxWfTRg==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.1",
-                "postcss-selector-parser": "^6.1.0"
+                "browserslist": "^4.23.3",
+                "postcss-selector-parser": "^6.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4743,9 +4789,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-            "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "dev": true,
             "funding": [
                 {
@@ -4797,15 +4843,12 @@
             "dev": true
         },
         "node_modules/v8flags": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
-            "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-4.0.1.tgz",
+            "integrity": "sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==",
             "dev": true,
-            "dependencies": {
-                "homedir-polyfill": "^1.0.1"
-            },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10.13.0"
             }
         },
         "node_modules/validate-npm-package-license": {

--- a/Src/TournamentCalendar/package.json
+++ b/Src/TournamentCalendar/package.json
@@ -8,12 +8,12 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
   "devDependencies": {
-    "autoprefixer": "10.4.19",
+    "autoprefixer": "10.4.20",
     "bootstrap": "5.3.3",
     "bootstrap-icons": "1.11.3",
-    "cssnano": "7.0.3",
+    "cssnano": "7.0.5",
     "grunt": "^1.6.1",
-    "grunt-cli": "1.4.3",
+    "grunt-cli": "1.5.0",
     "grunt-contrib-concat": "2.1.0",
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-cssmin": "5.0.0",
@@ -23,7 +23,7 @@
     "grunt-sass": "3.1.0",
     "jsnlog": "^2.30.0",
     "node-sass": "9.0.0",
-    "simple-datatables": "9.0.3",
+    "simple-datatables": "9.1.0",
     "@eonasdan/tempus-dominus": "6.9.6",
     "@popperjs/core": "2.11.8"
   },


### PR DESCRIPTION
Update npm packages
* simple-datatables: 9.0.3 => 9.1.0
* autoprefixer 10.4.19 => 10.4.20
* cssbabi; 7.0.3 => 7.0.5
* grunt-cli: 1.4.3 => 1.5.0

Fix: Set correct $bootstrap-icons-font-dir in _std-input.scss to '../lib/bootstrap/fonts' for bootstrap-icons package