### PR TITLE
Update various NuGet packages across multiple projects

### DIFF
--- a/Src/DAL/DatabaseGeneric/TournamentCalendarDAL.DbGeneric.csproj
+++ b/Src/DAL/DatabaseGeneric/TournamentCalendarDAL.DbGeneric.csproj
@@ -8,6 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.11.2" />
+    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.11.3" />
   </ItemGroup>
 </Project>

--- a/Src/DAL/DatabaseSpecific/TournamentCalendarDAL.DbSpecific.csproj
+++ b/Src/DAL/DatabaseSpecific/TournamentCalendarDAL.DbSpecific.csproj
@@ -8,6 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.11.2" />
+    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.11.3" />
   </ItemGroup>
 </Project>

--- a/Src/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
+++ b/Src/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
@@ -5,10 +5,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TournamentCalendar\TournamentCalendar.csproj" />

--- a/Src/TournamentCalendar/TournamentCalendar.csproj
+++ b/Src/TournamentCalendar/TournamentCalendar.csproj
@@ -65,10 +65,10 @@
     </PackageReference>
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.14" />
     <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/TournamentCalender.Data/TournamentCalender.Data.csproj
+++ b/Src/TournamentCalender.Data/TournamentCalender.Data.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DAL\DatabaseGeneric\TournamentCalendarDAL.DbGeneric.csproj" />


### PR DESCRIPTION
Updated the following packages:
- `SD.LLBLGen.Pro.ORMSupportClasses` to 5.11.3 in `TournamentCalendarDAL.DbGeneric.csproj`.
- `SD.LLBLGen.Pro.DQE.SqlServer` to 5.11.3 in `TournamentCalendarDAL.DbSpecific.csproj`.
- `Microsoft.NET.Test.Sdk` to 17.11.1, `NUnit` to 4.2.2, and `Microsoft.AspNetCore.Mvc.Testing` to 8.0.10 in `TournamentCalendar.Tests.csproj`.
- `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` to 8.0.10, `Microsoft.VisualStudio.Web.CodeGeneration.Design` to 8.0.6, and `System.Security.Cryptography.Xml` to 8.0.2 in `TournamentCalendar.csproj`.
- `Microsoft.Extensions.Logging` to 8.0.1 and `Microsoft.Extensions.Logging.Abstractions` to 8.0.2 in `TournamentCalender.Data.csproj`.