### PR TITLE
Switch to Microsoft.Data.SqlClient for database operations

### DIFF
--- a/Src/TournamentCalendar/Middleware/ClientAbortMiddleware.cs
+++ b/Src/TournamentCalendar/Middleware/ClientAbortMiddleware.cs
@@ -25,7 +25,7 @@ public class ClientAbortMiddleware : IMiddleware
         // If the cancellation token has not been requested,
         // it means that the exception was caused by the client closing the connection.
         // Note: SqlException with message "Operation cancelled by user may throw, too, but rarely.
-        catch (Exception ex) when (ex is TaskCanceledException or SqlException && context.RequestAborted.IsCancellationRequested)
+        catch (Exception ex) when (ex is TaskCanceledException or Microsoft.Data.SqlClient.SqlException && context.RequestAborted.IsCancellationRequested)
         {
             // Log the exception and stop the request queue.
             _logger.LogWarning("Request aborted by client: '{exception}'. Processing stops.", ex.GetType().ToString());

--- a/Src/TournamentCalendar/TournamentCalendar.csproj
+++ b/Src/TournamentCalendar/TournamentCalendar.csproj
@@ -58,6 +58,7 @@
     <PackageReference Include="cloudscribe.Web.Navigation" Version="8.0.0" />
     <PackageReference Include="JSNLog" Version="3.0.3" />
     <PackageReference Include="MailMergeLib" Version="5.12.3" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Src/TournamentCalendar/WebAppStartup.cs
+++ b/Src/TournamentCalendar/WebAppStartup.cs
@@ -191,13 +191,13 @@ public static class WebAppStartup
         {
             RuntimeConfiguration.ConfigureDQE<SD.LLBLGen.Pro.DQE.SqlServer.SQLServerDQEConfiguration>(c => c
                 .SetTraceLevel(TraceLevel.Off)
-                .AddDbProviderFactory(typeof(System.Data.SqlClient.SqlClientFactory)));
+                .AddDbProviderFactory(typeof(Microsoft.Data.SqlClient.SqlClientFactory)));
         }
         else
         {
-            RuntimeConfiguration.ConfigureDQE<SD.LLBLGen.Pro.DQE.SqlServer.SQLServerDQEConfiguration>(c => c
+            RuntimeConfiguration.ConfigureDQE<SD.LLBLGen.Pro.DQE.SqlServer.SQLServerDQEConfiguration>(static c => c
                 .SetTraceLevel(TraceLevel.Verbose)
-                .AddDbProviderFactory(typeof(System.Data.SqlClient.SqlClientFactory)));
+                .AddDbProviderFactory(typeof(Microsoft.Data.SqlClient.SqlClientFactory)));
 
             RuntimeConfiguration.Tracing.SetTraceLevel("ORMPersistenceExecution", TraceLevel.Verbose);
             RuntimeConfiguration.Tracing.SetTraceLevel("ORMPlainSQLQueryExecution", TraceLevel.Verbose);


### PR DESCRIPTION
- Updated ClientAbortMiddleware to handle Microsoft.Data.SqlClient.SqlException.
- Added Microsoft.Data.SqlClient package reference to TournamentCalendar.csproj.
- Changed database provider factory in WebAppStartup to Microsoft.Data.SqlClient.SqlClientFactory.