### PR TITLE
Connect to mssql server with domain name instead of id address

### DIFF
--- a/Src/TournamentCalendar/Configuration/Credentials.Production.json
+++ b/Src/TournamentCalendar/Configuration/Credentials.Production.json
@@ -1,5 +1,5 @@
 {
   "ConnectionStrings": {
-    "TournamentsMsSql": "Server=127.0.0.1;User Id=userId;Password=my!password!;Integrated Security=false;Connection Timeout=15;Pooling=true;Min Pool Size=1000;Max Pool Size=10000;MultipleActiveResultSets=true;TrustServerCertificate=true;"
+    "TournamentsMsSql": "Server=localhost;User Id=userId;Password=my!password!;Integrated Security=false;Connection Timeout=15;Pooling=true;Min Pool Size=1000;Max Pool Size=10000;MultipleActiveResultSets=true;"
   }
 }


### PR DESCRIPTION
Certificates may be installed for the domain name, but not for the ip address

Can be checked with
`openssl s_client -connect IPorDomainName:1433 -showcerts`
If the response contains `Can't use SSL_get_servername`, something is wrong with the `IPorDomainName` used