### PR TITLE
Update NuGet package references

### DIFF
--- a/Src/DAL/DatabaseGeneric/TournamentCalendarDAL.DbGeneric.csproj
+++ b/Src/DAL/DatabaseGeneric/TournamentCalendarDAL.DbGeneric.csproj
@@ -8,6 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.11.4" />
+    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.12.1" />
   </ItemGroup>
 </Project>

--- a/Src/DAL/DatabaseSpecific/TournamentCalendarDAL.DbSpecific.csproj
+++ b/Src/DAL/DatabaseSpecific/TournamentCalendarDAL.DbSpecific.csproj
@@ -8,6 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.11.4" />
+    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.12.1" />
   </ItemGroup>
 </Project>

--- a/Src/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
+++ b/Src/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />
-    <PackageReference Include="System.Text.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageReference Include="System.Text.Json" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TournamentCalendar\TournamentCalendar.csproj" />

--- a/Src/TournamentCalendar/TournamentCalendar.csproj
+++ b/Src/TournamentCalendar/TournamentCalendar.csproj
@@ -55,22 +55,22 @@
     <InternalsVisibleTo Include="TournamentCalendar.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Web.Navigation" Version="8.0.0" />
+    <PackageReference Include="cloudscribe.Web.Navigation" Version="8.1.0" />
     <PackageReference Include="JSNLog" Version="3.0.3" />
     <PackageReference Include="MailMergeLib" Version="5.12.3" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NLog.Web.AspNetCore" Version="5.4.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.5.0" />
     <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.17" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.4" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.6" />
+    <PackageReference Include="System.Text.Json" Version="9.0.6" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/TournamentCalender.Data/TournamentCalender.Data.csproj
+++ b/Src/TournamentCalender.Data/TournamentCalender.Data.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DAL\DatabaseGeneric\TournamentCalendarDAL.DbGeneric.csproj" />


### PR DESCRIPTION
- `SD.LLBLGen.Pro.ORMSupportClasses` and `SD.LLBLGen.Pro.DQE.SqlServer` upgraded to `5.12.1`.
- `Microsoft.NET.Test.Sdk` updated to `17.14.1`.
- `Microsoft.AspNetCore.Mvc.Testing` and `System.Text.Json` updated to `8.0.17` and `9.0.6`, respectively.
- `cloudscribe.Web.Navigation` upgraded to `8.1.0`.
- `Microsoft.Data.SqlClient` updated to `6.0.2`.
- `NLog.Web.AspNetCore` and `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` updated to `5.5.0` and `8.0.17`, respectively.
- `System.Security.Cryptography.Xml`, `Microsoft.Extensions.Logging`, and `Microsoft.Extensions.Logging.Abstractions` updated to `9.0.6`.