### PR TITLE
chore: upgrade NuGet packages across all projects

### DIFF
--- a/Src/DAL/DatabaseGeneric/TournamentCalendarDAL.DbGeneric.csproj
+++ b/Src/DAL/DatabaseGeneric/TournamentCalendarDAL.DbGeneric.csproj
@@ -8,6 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.13.0" />
+    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.13.1" />
   </ItemGroup>
 </Project>

--- a/Src/DAL/DatabaseSpecific/TournamentCalendarDAL.DbSpecific.csproj
+++ b/Src/DAL/DatabaseSpecific/TournamentCalendarDAL.DbSpecific.csproj
@@ -8,6 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.13.0" />
+    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.13.1" />
   </ItemGroup>
 </Project>

--- a/Src/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
+++ b/Src/TournamentCalendar.Tests/TournamentCalendar.Tests.csproj
@@ -5,11 +5,16 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TournamentCalendar\TournamentCalendar.csproj" />

--- a/Src/TournamentCalendar/TournamentCalendar.csproj
+++ b/Src/TournamentCalendar/TournamentCalendar.csproj
@@ -55,19 +55,22 @@
     <InternalsVisibleTo Include="TournamentCalendar.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Web.Navigation" Version="8.7.0" />
+    <PackageReference Include="cloudscribe.Web.Navigation" Version="10.0.0" />
     <PackageReference Include="JSNLog" Version="3.0.3" />
-    <PackageReference Include="MailMergeLib" Version="5.14.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
+    <PackageReference Include="MailMergeLib" Version="5.15.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NLog" Version="6.1.1" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
+    <PackageReference Include="NLog" Version="6.1.3" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
     <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/TournamentCalender.Data/TournamentCalender.Data.csproj
+++ b/Src/TournamentCalender.Data/TournamentCalender.Data.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DAL\DatabaseGeneric\TournamentCalendarDAL.DbGeneric.csproj" />


### PR DESCRIPTION
⚠️ Some of the packages were flagged as vulnerable.

TournamentCalendar:
- cloudscribe.Web.Navigation: 8.7.0 → 10.0.0
- Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation: 10.0.3 → 10.0.8
- Microsoft.Build.Tasks.Git: 10.0.103 → 10.0.300
- Microsoft.Data.SqlClient: 6.1.4 → 7.0.1
- Microsoft.Extensions.DependencyModel: 10.0.3 → 10.0.8
- Microsoft.IdentityModel.*: 8.14.0 / 7.7.1 → 8.16.0
- Microsoft.SourceLink.GitHub: 10.0.103 → 10.0.300
- NLog: 6.1.1 → 6.1.3
- NLog.Extensions.Logging: 6.1.2 → 6.1.3
- NLog.Web.AspNetCore: 6.1.2 → 6.1.3
- NuGet.Packaging/Protocol/Common/Configuration/Frameworks/Versioning: 6.14.3 → 7.6.0
- System.Configuration.ConfigurationManager: 9.0.11 → 9.0.13
- System.Security.Cryptography.ProtectedData: 9.0.11 → 9.0.13
- Removed: Azure.Core, Azure.Identity and related MSAL packages

TournamentCalender.Data:
- Microsoft.Extensions.*: 10.0.3 → 10.0.8

TournamentCalendarDAL.DbGeneric / DbSpecific:
- SD.LLBLGen.Pro.ORMSupportClasses: 5.13.0 → 5.13.1
- SD.LLBLGen.Pro.DQE.SqlServer: 5.13.0 → 5.13.1

TournamentCalendar.Tests:
- Microsoft.AspNetCore.Mvc.Testing: 10.0.3 → 10.0.8
- Microsoft.CodeCoverage: 18.3.0 → 18.6.0
- Microsoft.NET.Test.Sdk: 18.3.0 → 18.6.0
- NuGet.Packaging/Protocol: 6.14.3 → 7.6.0
- NUnit: 4.5.1 → 4.6.1
- NUnit3TestAdapter: 6.1.0 → 6.2.0
- System.Drawing.Common: 4.7.3 → 10.0.8
- System.Security.Cryptography.Xml: 4.7.1 → 10.0.8